### PR TITLE
Make the source compatible to java 1.8

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -61,8 +61,8 @@
 
     <properties>
         <jackson.version>2.9.6</jackson.version>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/api/src/main/java/io/cloudevents/impl/ZonedDateTimeSerializer.java
+++ b/api/src/main/java/io/cloudevents/impl/ZonedDateTimeSerializer.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2018 The CloudEvents Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.impl;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class ZonedDateTimeSerializer extends StdSerializer<ZonedDateTime> {
+
+	private static final long serialVersionUID = 6245182835980474796L;
+
+	public ZonedDateTimeSerializer() {
+		this(null, false);
+	}
+
+	protected ZonedDateTimeSerializer(Class<?> t, boolean dummy) {
+		super(t, dummy);
+	}
+
+	@Override
+	public void serialize(ZonedDateTime time, JsonGenerator generator,
+			SerializerProvider provider) throws IOException {
+
+		generator.writeString(time.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+
+	}
+
+}

--- a/api/src/test/java/io/cloudevents/CloudEventBuilderTest.java
+++ b/api/src/test/java/io/cloudevents/CloudEventBuilderTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +31,9 @@ public class CloudEventBuilderTest {
     public void testBuilderWithData() {
 
         // given
-        final Map<String, String> keyValueStore = Map.of("key1", "value1", "key2", "val2");
+        final Map<String, String> keyValueStore = new HashMap<>();
+        keyValueStore.put("key1", "value1");
+        keyValueStore.put("key2", "value2");
         final String eventId = UUID.randomUUID().toString();
         final URI src = URI.create("/trigger");
         final String eventType = "My.Cloud.Event.Type";
@@ -38,7 +41,8 @@ public class CloudEventBuilderTest {
         final ZonedDateTime eventTime = ZonedDateTime.now();
         final String contentType = "application/json";
         final URI schemaUri = URI.create("http://cloudevents.io/schema");
-        final Map<String, String> extensionData = Map.of("foo", "bar");
+        final Map<String, String> extensionData = new HashMap<>();
+        extensionData.put("foo", "bar");
 
         // when
         final CloudEvent<Map<String, String>> simpleKeyValueEvent = new CloudEventBuilder()


### PR DESCRIPTION
Signed-off-by: Fabio José <fabiojose@gmail.com>

In our company we have strong compliance rules and at this moment we are able to use just java 1.8.

Could you accept these changes to make the impl. compatible to java 1.8?