### PR TITLE
#70 Implement dataref extension

### DIFF
--- a/api/src/main/java/io/cloudevents/extensions/DatarefExtension.java
+++ b/api/src/main/java/io/cloudevents/extensions/DatarefExtension.java
@@ -1,0 +1,110 @@
+package io.cloudevents.extensions;
+
+import java.net.URI;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class DatarefExtension {
+
+  private URI dataref;
+
+  public URI getDataref() {
+    return dataref;
+  }
+
+  public void setDataref(URI dataref) {
+    this.dataref = dataref;
+  }
+
+  @Override
+  public String toString() {
+    return "DatarefExtension{" +
+        "dataref='" + dataref + '\'' +
+        '}';
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((dataref == null) ? 0
+        : dataref.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    DatarefExtension other = (DatarefExtension) obj;
+    if (dataref == null) {
+      return other.dataref == null;
+    } else {
+      return dataref.equals(other.dataref);
+    }
+  }
+
+  /**
+   * The in-memory format for dataref.
+   */
+  public static class Format implements ExtensionFormat {
+
+    public static final String IN_MEMORY_KEY = "dataref";
+    public static final String DATAREF_KEY = "dataref";
+
+    private final InMemoryFormat memory;
+    private final Map<String, String> transport = new HashMap<>();
+
+    public Format(DatarefExtension extension) {
+      Objects.requireNonNull(extension);
+
+      memory = InMemoryFormat.of(IN_MEMORY_KEY, extension,
+          DatarefExtension.class);
+
+      transport.put(DATAREF_KEY, extension.getDataref().toString());
+    }
+
+    @Override
+    public InMemoryFormat memory() {
+      return memory;
+    }
+
+    @Override
+    public Map<String, String> transport() {
+      return transport;
+    }
+  }
+
+  /**
+   * Unmarshals the {@link DatarefExtension} based on map of extensions.
+   */
+  public static Optional<ExtensionFormat> unmarshall(Map<String, String> exts) {
+    String dataref = exts.get(Format.DATAREF_KEY);
+
+    if (null != dataref) {
+      DatarefExtension datarefExtension = new DatarefExtension();
+      datarefExtension.setDataref(URI.create(dataref));
+
+      InMemoryFormat inMemory = InMemoryFormat
+          .of(Format.IN_MEMORY_KEY, datarefExtension, DatarefExtension.class);
+
+      return Optional.of(
+          ExtensionFormat.of(inMemory,
+              new SimpleEntry<>(Format.DATAREF_KEY, dataref))
+      );
+
+    }
+
+    return Optional.empty();
+  }
+}

--- a/api/src/main/java/io/cloudevents/v1/http/Unmarshallers.java
+++ b/api/src/main/java/io/cloudevents/v1/http/Unmarshallers.java
@@ -15,6 +15,7 @@
  */
 package io.cloudevents.v1.http;
 
+import io.cloudevents.extensions.DatarefExtension;
 import io.cloudevents.extensions.DistributedTracingExtension;
 import io.cloudevents.format.BinaryUnmarshaller;
 import io.cloudevents.format.StructuredUnmarshaller;
@@ -53,6 +54,7 @@ public class Unmarshallers {
 				.next()
 				.map(ExtensionMapper::map)
 				.map(DistributedTracingExtension::unmarshall)
+				.map(DatarefExtension::unmarshall)
 				.next()
 				.builder(CloudEventBuilder.<T>builder()::build);
 	}
@@ -74,6 +76,7 @@ public class Unmarshallers {
 		  builder()
 			.map(ExtensionMapper::map)
 			.map(DistributedTracingExtension::unmarshall)
+			.map(DatarefExtension::unmarshall)
 			.next()
 			.map((payload, extensions) -> {			
 				CloudEventImpl<T> event =

--- a/api/src/test/java/io/cloudevents/extensions/DatarefExtensionTest.java
+++ b/api/src/test/java/io/cloudevents/extensions/DatarefExtensionTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2019 The CloudEvents Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cloudevents.extensions;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import org.junit.Test;
+
+public class DatarefExtensionTest {
+
+  @Test
+  public void should_transport_format_ok() {
+    // setup
+    DatarefExtension datarefExtension = new DatarefExtension();
+    datarefExtension.setDataref(URI.create("/dataref"));
+
+    // act
+    ExtensionFormat format = new DatarefExtension.Format(datarefExtension);
+
+    // assert
+    assertEquals("/dataref", format.transport().get("dataref"));
+  }
+
+  @Test
+  public void should_inmemory_format_ok() {
+    // setup
+    DatarefExtension datarefExtension = new DatarefExtension();
+    datarefExtension.setDataref(URI.create("/dataref"));
+
+    // act
+    ExtensionFormat format = new DatarefExtension.Format(datarefExtension);
+
+    // assert
+    assertEquals("dataref", format.memory().getKey());
+    assertEquals(DatarefExtension.class, format.memory().getValueType());
+
+    assertEquals("/dataref",
+        ((DatarefExtension) format.memory().getValue()).getDataref().toString());
+  }
+}

--- a/api/src/test/java/io/cloudevents/v1/AccessorTest.java
+++ b/api/src/test/java/io/cloudevents/v1/AccessorTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import io.cloudevents.extensions.DatarefExtension;
 import java.net.URI;
 import java.util.Collection;
 
@@ -93,6 +94,37 @@ public class AccessorTest {
 		
 		assertEquals("congo=4", 
 				((DistributedTracingExtension)actual.memory().getValue()).getTracestate());
+	}
+
+	@Test
+	public void should_return_the_dataref_extension() {
+		// setup
+		final DatarefExtension datarefExtension = new DatarefExtension();
+		datarefExtension.setDataref(URI.create("/dataref"));
+
+		final ExtensionFormat expected = new DatarefExtension.Format(datarefExtension);
+
+		CloudEventImpl<Object> ce =
+				CloudEventBuilder.<Object>builder()
+						.withId("x10")
+						.withSource(URI.create("/source"))
+						.withType("event-type")
+						.withDataschema(URI.create("/schema"))
+						.withDataContentType("text/plain")
+						.withData("my-data")
+						.withExtension(expected)
+						.build();
+
+		// act
+		Collection<ExtensionFormat> extensions = Accessor.extensionsOf(ce);
+
+		// assert
+		assertFalse(extensions.isEmpty());
+		ExtensionFormat actual = extensions.iterator().next();
+
+		assertEquals("/dataref", actual.transport().get("dataref"));
+		assertEquals("/dataref",
+				((DatarefExtension)actual.memory().getValue()).getDataref().toString());
 	}
 	
 	@Test

--- a/api/src/test/java/io/cloudevents/v1/CloudEventBuilderTest.java
+++ b/api/src/test/java/io/cloudevents/v1/CloudEventBuilderTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.cloudevents.extensions.DatarefExtension;
 import java.net.URI;
 
 import org.junit.Rule;
@@ -165,6 +166,31 @@ public class CloudEventBuilderTest {
 		// assert
 		assertNotNull(actual);
 		assertTrue(actual instanceof DistributedTracingExtension);
+	}
+
+	@Test
+	public void should_have_dataref_extension() {
+		// setup
+		final DatarefExtension datarefExtension = new DatarefExtension();
+		datarefExtension.setDataref(URI.create("/dataref"));
+
+		final ExtensionFormat tracing = new DatarefExtension.Format(datarefExtension);
+
+		// act
+		CloudEventImpl<Object> ce =
+				CloudEventBuilder.builder()
+						.withId("id")
+						.withSource(URI.create("/source"))
+						.withType("type")
+						.withExtension(tracing)
+						.build();
+
+		Object actual = ce.getExtensions()
+				.get(DatarefExtension.Format.IN_MEMORY_KEY);
+
+		// assert
+		assertNotNull(actual);
+		assertTrue(actual instanceof DatarefExtension);
 	}
 	
 	@Test

--- a/api/src/test/java/io/cloudevents/v1/CloudEventJacksonTest.java
+++ b/api/src/test/java/io/cloudevents/v1/CloudEventJacksonTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.cloudevents.extensions.DatarefExtension;
 import java.io.InputStream;
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -136,6 +137,33 @@ public class CloudEventJacksonTest {
 		// assert
 		assertTrue(actual.contains(expected));
 	}
+
+  @Test
+  public void should_serialize_dataref_extension() {
+    // setup
+    String expected = "\"dataref\":\"/dataref\"";
+    final DatarefExtension datarefExtension = new DatarefExtension();
+    datarefExtension.setDataref(URI.create("/dataref"));
+
+    final ExtensionFormat extension = new DatarefExtension.Format(datarefExtension);
+
+    CloudEvent<AttributesImpl, Object> ce =
+        CloudEventBuilder.builder()
+            .withId("x10")
+            .withSource(URI.create("/source"))
+            .withType("event-type")
+            .withDataschema(URI.create("/schema"))
+            .withDataContentType("text/plain")
+            .withData("my-data")
+            .withExtension(extension)
+            .build();
+
+    // act
+    String actual = Json.encode(ce);
+
+    // assert
+    assertTrue(actual.contains(expected));
+  }
 	
 	@Test
 	public void should_not_serialize_attributes_element() {
@@ -251,7 +279,18 @@ public class CloudEventJacksonTest {
         assertNotNull(ce.getExtensions()
         	.get(DistributedTracingExtension.Format.IN_MEMORY_KEY));
     }
-	
+
+  @Test
+  public void should_have_dataref_extension() {
+    // act
+    CloudEvent<AttributesImpl, Object> ce =
+        Json.fromInputStream(resourceOf("1_extension.json"), CloudEventImpl.class);
+
+    // assert
+    assertNotNull(ce.getExtensions()
+        .get(DatarefExtension.Format.IN_MEMORY_KEY));
+  }
+
 	@Test
     public void should_have_custom_extension() {
 		// setup

--- a/api/src/test/java/io/cloudevents/v1/http/ExtensionMapperTest.java
+++ b/api/src/test/java/io/cloudevents/v1/http/ExtensionMapperTest.java
@@ -60,12 +60,12 @@ public class ExtensionMapperTest {
 		myHeaders.put("my-ext", "myextension");
 		myHeaders.put("traceparent", "0");
 		myHeaders.put("tracestate", "congo=4");
+		myHeaders.put("dataref", "/dataref");
 		myHeaders.put("Content-Type", "application/json");
 		myHeaders.put(expected, null);
 		
 		// act
 		Map<String, String> actual = ExtensionMapper.map(myHeaders);
-		
 		
 		// assert
 		assertFalse(actual.containsKey(expected));
@@ -84,6 +84,7 @@ public class ExtensionMapperTest {
 		myHeaders.put("my-ext", "myextension");
 		myHeaders.put("traceparent", "0");
 		myHeaders.put("tracestate", "congo=4");
+		myHeaders.put("dataref", "/dataref");
 		myHeaders.put("Content-Type", "application/json");
 		
 		// act
@@ -91,7 +92,7 @@ public class ExtensionMapperTest {
 		
 		// asset
 		assertFalse(actual.isEmpty());
-		assertEquals(3, actual.keySet().size());
+		assertEquals(4, actual.keySet().size());
 		actual.keySet()
 			.forEach(header -> {
 				assertFalse(header.startsWith("ce-"));
@@ -99,6 +100,7 @@ public class ExtensionMapperTest {
 		
 		assertEquals("0", actual.get("traceparent"));
 		assertEquals("congo=4", actual.get("tracestate"));
+		assertEquals("/dataref", actual.get("dataref"));
 		assertEquals("myextension", actual.get("my-ext"));
 	}
 }

--- a/api/src/test/java/io/cloudevents/v1/http/HTTPBinaryMarshallerTest.java
+++ b/api/src/test/java/io/cloudevents/v1/http/HTTPBinaryMarshallerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.cloudevents.extensions.DatarefExtension;
 import java.net.URI;
 import java.util.Base64;
 
@@ -160,5 +161,32 @@ public class HTTPBinaryMarshallerTest {
 				.Format.TRACE_PARENT_KEY));
 		assertNotNull(actual.getHeaders().get(DistributedTracingExtension
 				.Format.TRACE_STATE_KEY));
+	}
+
+	@Test
+	public void should_marshal_the_dataref_extension_as_header() {
+		// setup
+		final DatarefExtension datarefExtension = new DatarefExtension();
+		datarefExtension.setDataref(URI.create("/dataref"));
+
+		final ExtensionFormat extension = new DatarefExtension.Format(datarefExtension);
+
+		CloudEventImpl<String> ce =
+				CloudEventBuilder.<String>builder()
+						.withId("id")
+						.withSource(URI.create("/source"))
+						.withType("type")
+						.withExtension(extension)
+						.build();
+
+		// act
+		Wire<String, String, String> actual =
+				Marshallers.<String>
+						binary()
+						.withEvent(() -> ce)
+						.marshal();
+
+		assertFalse(actual.getHeaders().isEmpty());
+		assertNotNull(actual.getHeaders().get(DatarefExtension.Format.DATAREF_KEY));
 	}
 }

--- a/api/src/test/java/io/cloudevents/v1/http/HTTPBinaryUnmarshallerTest.java
+++ b/api/src/test/java/io/cloudevents/v1/http/HTTPBinaryUnmarshallerTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.cloudevents.extensions.DatarefExtension;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -111,5 +112,37 @@ public class HTTPBinaryUnmarshallerTest {
 		assertTrue(actual.getExtensions()
 			.get(DistributedTracingExtension.Format.IN_MEMORY_KEY) 
 				instanceof DistributedTracingExtension);
+	}
+
+	@Test
+	public void should_unmarshal_dataref_extension_from_header() {
+		// setup
+		Much expected = new Much();
+		expected.setWow("yes!");
+
+		Map<String, Object> myHeaders = new HashMap<>();
+		myHeaders.put("ce-id", "0x11");
+		myHeaders.put("ce-source", "/source");
+		myHeaders.put("ce-specversion", "1.0");
+		myHeaders.put("ce-type", "br.my");
+		myHeaders.put("ce-time", "2019-09-16T20:49:00Z");
+		myHeaders.put("ce-schemaurl", "http://my.br");
+		myHeaders.put("Content-Type", "application/json");
+
+		myHeaders.put("dataref", "/dataref");
+
+		String payload = "{\"wow\":\"yes!\"}";
+
+		// act
+		CloudEvent<AttributesImpl, Much> actual =
+				Unmarshallers.binary(Much.class)
+						.withHeaders(() -> myHeaders)
+						.withPayload(() -> payload)
+						.unmarshal();
+
+		// assert
+		assertNotNull(actual.getExtensions().get(DatarefExtension.Format.IN_MEMORY_KEY));
+		assertTrue(actual.getExtensions().get(DatarefExtension.Format.IN_MEMORY_KEY)
+				instanceof DatarefExtension);
 	}
 }

--- a/api/src/test/java/io/cloudevents/v1/http/HTTPStructuredMarshallerTest.java
+++ b/api/src/test/java/io/cloudevents/v1/http/HTTPStructuredMarshallerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.cloudevents.extensions.DatarefExtension;
 import java.net.URI;
 
 import org.junit.Test;
@@ -94,5 +95,32 @@ public class HTTPStructuredMarshallerTest {
 				.Format.TRACE_PARENT_KEY));
 		assertNotNull(actual.getHeaders().get(DistributedTracingExtension
 				.Format.TRACE_STATE_KEY));
+	}
+
+	@Test
+	public void should_marshal_the_dataref_extension_as_header() {
+		// setup
+		final DatarefExtension datarefExtension = new DatarefExtension();
+		datarefExtension.setDataref(URI.create("/dataref"));
+
+		final ExtensionFormat tracing = new DatarefExtension.Format(datarefExtension);
+
+		CloudEventImpl<String> ce =
+				CloudEventBuilder.<String>builder()
+						.withId("id")
+						.withSource(URI.create("/source"))
+						.withType("type")
+						.withExtension(tracing)
+						.build();
+
+		// act
+		Wire<String, String, String> actual =
+				Marshallers.<String>structured()
+						.withEvent(() -> ce)
+						.marshal();
+
+		// assert
+		assertFalse(actual.getHeaders().isEmpty());
+		assertNotNull(actual.getHeaders().get(DatarefExtension.Format.DATAREF_KEY));
 	}
 }

--- a/api/src/test/java/io/cloudevents/v1/http/HTTPStructuredUnmarshallerTest.java
+++ b/api/src/test/java/io/cloudevents/v1/http/HTTPStructuredUnmarshallerTest.java
@@ -18,6 +18,7 @@ package io.cloudevents.v1.http;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import io.cloudevents.extensions.DatarefExtension;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -154,5 +155,28 @@ public class HTTPStructuredUnmarshallerTest {
 		assertTrue(actual.getExtensions().get(
 				DistributedTracingExtension.Format.IN_MEMORY_KEY) 
 					instanceof DistributedTracingExtension);
+	}
+
+	@Test
+	public void should_unmarshal_the_dataref_extension_from_headers() {
+		// setup
+		Map<String, Object> httpHeaders = new HashMap<>();
+		httpHeaders.put("Content-Type", "application/cloudevents+json");
+
+		httpHeaders.put("dataref", "/dataref");
+
+		String json = "{\"data\":\"yes!\",\"id\":\"x10\",\"source\":\"/source\",\"specversion\":\"1.0\",\"type\":\"event-type\",\"datacontenttype\":\"text/plain\"}";
+
+		// act
+		CloudEvent<AttributesImpl, String> actual =
+				Unmarshallers.structured(String.class)
+						.withHeaders(() -> httpHeaders)
+						.withPayload(() -> json)
+						.unmarshal();
+
+		// assert
+		assertTrue(actual.getExtensions().containsKey(DatarefExtension.Format.IN_MEMORY_KEY));
+		assertTrue(actual.getExtensions().get(DatarefExtension.Format.IN_MEMORY_KEY)
+				instanceof DatarefExtension);
 	}
 }

--- a/api/src/test/resources/1_extension.json
+++ b/api/src/test/resources/1_extension.json
@@ -23,5 +23,6 @@
   "distributedTracing": {
   	"traceparent": "0",
   	"tracestate": "congo=4"
-  }
+  },
+  "dataref": "/dataref"
 }


### PR DESCRIPTION
See issue #70 

I have implemented the `dataref` extension based on the spec https://github.com/cloudevents/spec/blob/master/extensions/dataref.md and following the implementation for the tracing extension already provided in this SDK.