### PR TITLE
Fix Kafka Transport references

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ and unmarshallers with HTTP transport binding.
 
 ## Kafka
 
-The support for kafka transport binding is available. Read the
+The support for kafka protocol binding is available. Read the
 [documentation and examples](./kafka/README.md) of use.
 
 ## Possible Integrations

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,8 +1,8 @@
-# CloudEvents Kafka Transport Binding
+# CloudEvents Kafka Protocol Binding
 
-The impl of Kafka Transport Biding for CloudEvents.
+The impl of Kafka Protocol Biding for CloudEvents.
 
-> See spec [here](https://github.com/cloudevents/spec/blob/master/kafka-transport-binding.md)
+> See spec [here](https://github.com/cloudevents/spec/blob/master/kafka-protocol-binding.md)
 
 ## How to Use
 


### PR DESCRIPTION
Docs say Transport. Actual link should go to protocol. 