### PR TITLE
Add new CloudEventsKafkaHeaders class for kafka API

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -67,7 +67,6 @@ try(CloudEventsKafkaProducer<String, AttributesImpl, String>
 	ceProducer.send(new ProducerRecord<>("your.topic", ce));
 }
 ```
-
 #### Structured Content Mode
 
 ```java
@@ -112,6 +111,16 @@ try(CloudEventsKafkaProducer<String, AttributesImpl, String>
 	// Produce the event
 	ceProducer.send(new ProducerRecord<>("your.topic", ce));
 }
+```
+
+### Build Kafka headers for CloudEvents
+
+```java
+// for Binary Content Mode
+Iterable<Header> headers = CloudEventsKafkaHeaders.buildHeaders(ce, Marshallers.binary());
+
+// for Structured Content Mode
+Iterable<Header> headers = CloudEventsKafkaHeaders.buildHeaders(ce, Marshallers.structured());
 ```
 
 ### Consumer

--- a/kafka/src/main/java/io/cloudevents/kafka/CloudEventsKafkaHeaders.java
+++ b/kafka/src/main/java/io/cloudevents/kafka/CloudEventsKafkaHeaders.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2019 The CloudEvents Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.kafka;
+
+import io.cloudevents.Attributes;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.format.Wire;
+import io.cloudevents.format.builder.EventStep;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class for building the Kafka headers that should be attached either a binary or structured event message.
+ *
+ * @author Florian Hussonnois
+ */
+public class CloudEventsKafkaHeaders {
+
+    /**
+     * Static helper to create Kafka {@link org.apache.kafka.common.header.Headers} for the given {@link CloudEvent}.
+     *
+     * @param event     the {@link CloudEvent} to be used for creating corresponding Kafka headers.
+     * @param builder   the {@link EventStep} to be used for building the headers.
+     * @return  the {@link org.apache.kafka.common.header.Headers}
+     */
+    public static <T, A extends Attributes> Iterable<Header> buildHeaders(final CloudEvent<A, T> event,
+                                                                          final EventStep<A, T, byte[], byte[]> builder) {
+        return getHeaders(event, builder);
+    }
+
+    private static <T, A extends Attributes> Iterable<Header> getHeaders(final CloudEvent<A, T> event,
+                                                                         final EventStep<A, T, byte[], byte[]> marshaller) {
+        Wire<byte[], String, byte[]> marshal = marshaller.withEvent(() -> event).marshal();
+        Map<String, byte[]> headers = marshal.getHeaders();
+        return marshal(headers);
+    }
+
+    /**
+     * Casts the Object value of header into byte[]. This is
+     * guaranteed by the HeaderMapper implementation
+     *
+     * @param headers   the headers to convert.
+     * @return          the set of {@link Header}.
+     */
+    static Set<Header> marshal(Map<String, byte[]> headers) {
+        return headers.entrySet()
+            .stream()
+            .map(header ->
+                    new AbstractMap.SimpleEntry<>(header.getKey(), header.getValue()))
+            .map(header -> new RecordHeader(header.getKey(), header.getValue()))
+            .collect(Collectors.toSet());
+    }
+}
+

--- a/kafka/src/main/java/io/cloudevents/kafka/CloudEventsKafkaProducer.java
+++ b/kafka/src/main/java/io/cloudevents/kafka/CloudEventsKafkaProducer.java
@@ -18,7 +18,6 @@ package io.cloudevents.kafka;
 import static java.util.Optional.ofNullable;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 
-import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -28,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
@@ -42,7 +40,6 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,29 +117,10 @@ public class CloudEventsKafkaProducer<K, A extends Attributes, T> implements
 		
 	}
 	
-	/**
-	 * Casts the Object value of header into byte[]. This is
-	 * guaranteed by the HeaderMapper implementation
-	 * 
-	 * @param headers
-	 * @return
-	 */
-	private Set<Header> marshal(Map<String, byte[]> headers) {
-
-		return 
-		  headers.entrySet()
-			.stream()
-			.map(header -> 
-				new SimpleEntry<>(header.getKey(), header.getValue()))
-			.map(header -> new RecordHeader(header.getKey(), header.getValue()))
-			.collect(Collectors.toSet());
-		
-	}
-	
 	private ProducerRecord<K, byte[]> marshal(ProducerRecord<K, CloudEvent<A, T>>
 			event) {
 		Wire<byte[], String, byte[]> wire = marshal(() -> event.value());
-		Set<Header> headers = marshal(wire.getHeaders());
+		Set<Header> headers = CloudEventsKafkaHeaders.marshal(wire.getHeaders());
 		
 		byte[] payload = wire
 				.getPayload()

--- a/kafka/src/test/java/io/cloudevents/kafka/CloudEventsKafkaHeadersTest.java
+++ b/kafka/src/test/java/io/cloudevents/kafka/CloudEventsKafkaHeadersTest.java
@@ -1,0 +1,55 @@
+package io.cloudevents.kafka;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.v1.AttributesImpl;
+import io.cloudevents.v1.CloudEventBuilder;
+import io.cloudevents.v1.kafka.Marshallers;
+import org.apache.kafka.common.header.Header;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class CloudEventsKafkaHeadersTest {
+
+    private final CloudEvent<AttributesImpl, String> ce =
+        CloudEventBuilder.<String>builder()
+            .withId("x10")
+            .withSource(URI.create("/source"))
+            .withType("event-type")
+            .withDataContentType("application/json")
+            .build();
+
+    @Test
+    public void should_create_headers_given_binary_marshaller() {
+        Iterable<Header> headers = CloudEventsKafkaHeaders.buildHeaders(ce, Marshallers.binary());
+        assertHeaders(headers, new HashMap<String, String>(){{
+            put("ce_id", "x10");
+            put("ce_type", "event-type");
+            put("ce_specversion", "1.0");
+            put("ce_source", "/source");
+            put("content-type", "application/json");
+        }});
+    }
+
+    @Test
+    public void should_create_headers_given_structured_marshaller() {
+        Iterable<Header> headers = CloudEventsKafkaHeaders.buildHeaders(ce, Marshallers.structured());
+        assertHeaders(headers, Collections.singletonMap("content-type", "application/cloudevents+json"));
+    }
+
+    private void assertHeaders(final Iterable<Header> headers, final Map<String, String> expected) {
+        Map<String, String> values = StreamSupport.stream(headers.spliterator(), false)
+                .collect(Collectors.toMap(Header::key, h -> new String(h.value(), StandardCharsets.UTF_8)));
+
+        for (Map.Entry<String, String> expectedHeader : expected.entrySet()) {
+            Assertions.assertEquals(expectedHeader.getValue(), values.get(expectedHeader.getKey()));
+        }
+    }
+}


### PR DESCRIPTION
Currently, it may be restrictive to use only the `CloudEventsKafkaProducer` class, which seems to support only JSON serialization. 

Developers should be able to use the KafkaProducer class directly, e.g. to use a custom or vender-type serializer (e.g. the Avro Confluent serializer), while still benefiting from this SDK.

This commit add a new CloudEventsKafkaHeaders helper class used to build the Kafka headers
that should be attached either a binary or structured event message.