### PR TITLE
Streamline CloudEvent strategy to ensure it's clean from any assumption

### DIFF
--- a/api/src/main/java/io/cloudevents/CloudEvent.java
+++ b/api/src/main/java/io/cloudevents/CloudEvent.java
@@ -16,13 +16,13 @@
  */
 package io.cloudevents;
 
-import io.cloudevents.format.EventFormat;
-import io.cloudevents.lang.Nullable;
-import io.cloudevents.message.BinaryMessage;
-import io.cloudevents.message.StructuredMessage;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Map;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Map;
+
+import io.cloudevents.lang.Nullable;
 
 /**
  * An abstract event envelope
@@ -33,45 +33,60 @@ import java.util.Map;
 @ParametersAreNonnullByDefault
 public interface CloudEvent {
 
-    /**
-     * The event context attributes
-     */
-    Attributes getAttributes();
-
-    /**
-     * The event data
-     */
+	/**
+	 *
+	 * @return the event data, effectively representing the payload of this event.
+	 */
     @Nullable
     byte[] getData();
 
     /**
-     * The event extensions
-     * <p>
-     * Extensions values could be String/Number/Boolean
+     * @return the version of the Cloud Events specification which this event uses.
      */
+    SpecVersion getSpecVersion();
+
+	/**
+	 * @return  The identifier of this event. Producers MUST ensure that {@link #getSource()} + {@link #getId()} is unique for each distinct event.
+	 */
+	String getId();
+
+	/**
+	 * @return a value describing the type of event related to the originating occurrence.
+	 */
+	String getType();
+
+	/**
+	 * @return the context in which an event happened.
+	 */
+	URI getSource();
+
+	/**
+	 * @return the content type of data value. It MUST follows the <a href="https://tools.ietf.org/html/rfc2046">RFC2046</a>
+	 */
+	@Nullable
+	String getDataContentType();
+
+	/**
+	 * @return the schema that data adheres to.
+	 */
+	@Nullable
+	URI getDataSchema();
+
+	/**
+	 * @return the subject of the event in the context of the event producer (identified by {@link #getSource()}).
+	 */
+	@Nullable
+	String getSubject();
+
+	/**
+	 * @return Timestamp of when the occurrence happened.
+	 */
+	@Nullable
+	ZonedDateTime getTime();
+
+	/**
+	 *
+	 * @return the event extensions. Extensions values could be String/Number/Boolean
+	 */
     Map<String, Object> getExtensions();
-
-    CloudEvent toV03();
-
-    CloudEvent toV1();
-
-    BinaryMessage asBinaryMessage();
-
-    StructuredMessage asStructuredMessage(EventFormat format);
-
-    static io.cloudevents.v1.CloudEventBuilder buildV1() {
-        return new io.cloudevents.v1.CloudEventBuilder();
-    }
-
-    static io.cloudevents.v1.CloudEventBuilder buildV1(CloudEvent event) {
-        return new io.cloudevents.v1.CloudEventBuilder(event);
-    }
-
-    static io.cloudevents.v03.CloudEventBuilder buildV03() {
-        return new io.cloudevents.v03.CloudEventBuilder();
-    }
-
-    static io.cloudevents.v03.CloudEventBuilder buildV03(CloudEvent event) {
-        return new io.cloudevents.v03.CloudEventBuilder(event);
-    }
 }

--- a/api/src/main/java/io/cloudevents/impl/CloudEventUtils.java
+++ b/api/src/main/java/io/cloudevents/impl/CloudEventUtils.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2020 The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.impl;
+
+import java.util.Map;
+
+import io.cloudevents.Attributes;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.format.EventFormat;
+import io.cloudevents.message.BinaryMessage;
+import io.cloudevents.message.BinaryMessageAttributes;
+import io.cloudevents.message.BinaryMessageExtensionsVisitor;
+import io.cloudevents.message.BinaryMessageVisitor;
+import io.cloudevents.message.BinaryMessageVisitorFactory;
+import io.cloudevents.message.MessageVisitException;
+import io.cloudevents.message.StructuredMessage;
+import io.cloudevents.message.StructuredMessageVisitor;
+import io.cloudevents.v1.AttributesImpl;
+
+/**
+ * Set of miscellaneous utility methods to manipulate various aspects of {@link CloudEvent}.
+ *
+ * Mainly for internal use within the framework
+ */
+public abstract class CloudEventUtils {
+
+	public static io.cloudevents.v1.CloudEventBuilder buildV1() {
+		return new io.cloudevents.v1.CloudEventBuilder();
+	}
+
+	public static io.cloudevents.v1.CloudEventBuilder buildV1(CloudEvent event) {
+		return new io.cloudevents.v1.CloudEventBuilder(event);
+	}
+
+	public static io.cloudevents.v03.CloudEventBuilder buildV03() {
+		return new io.cloudevents.v03.CloudEventBuilder();
+	}
+
+	public static io.cloudevents.v03.CloudEventBuilder buildV03(CloudEvent event) {
+		return new io.cloudevents.v03.CloudEventBuilder(event);
+	}
+
+	public static CloudEvent toV03(CloudEvent cloudEvent) {
+		return new CloudEventImpl(extractAttributes(cloudEvent).toV03(), cloudEvent.getData(),
+				cloudEvent.getExtensions());
+	}
+
+	public static CloudEvent toV1(CloudEvent cloudEvent) {
+		return new CloudEventImpl(extractAttributes(cloudEvent).toV1(), cloudEvent.getData(),
+				cloudEvent.getExtensions());
+	}
+
+	public static Attributes extractAttributes(CloudEvent cloudEvent) {
+		if (cloudEvent instanceof CloudEventImpl) {
+			return ((CloudEventImpl) cloudEvent).getAttributes();
+		} else {
+			return new AttributesImpl(cloudEvent.getId(), cloudEvent.getSource(), cloudEvent.getType(),
+					cloudEvent.getDataContentType(), cloudEvent.getDataSchema(), cloudEvent.getSubject(),
+					cloudEvent.getTime());
+		}
+	}
+
+	public static BinaryMessage asBinaryMessage(CloudEvent cloudEvent) {
+		return new BinaryMessage() {
+			@Override
+			public <V extends BinaryMessageVisitor<R>, R> R visit(BinaryMessageVisitorFactory<V, R> visitorFactory)
+					throws MessageVisitException, IllegalStateException {
+				return CloudEventUtils.visit(cloudEvent, visitorFactory);
+			}
+		};
+	}
+
+	public static StructuredMessage asStructuredMessage(CloudEvent cloudEvent, EventFormat format) {
+		// TODO This sucks, will improve later
+		return new StructuredMessage() {
+			@Override
+			public <T> T visit(StructuredMessageVisitor<T> visitor)
+					throws MessageVisitException, IllegalStateException {
+				return visitor.setEvent(format, format.serialize(cloudEvent));
+			}
+		};
+	}
+
+	public static void visitExtensions(CloudEvent cloudEvent, BinaryMessageExtensionsVisitor visitor) throws MessageVisitException {
+		// TODO to be improved
+		for (Map.Entry<String, Object> entry : cloudEvent.getExtensions().entrySet()) {
+			if (entry.getValue() instanceof String) {
+				visitor.setExtension(entry.getKey(), (String) entry.getValue());
+			} else if (entry.getValue() instanceof Number) {
+				visitor.setExtension(entry.getKey(), (Number) entry.getValue());
+			} else if (entry.getValue() instanceof Boolean) {
+				visitor.setExtension(entry.getKey(), (Boolean) entry.getValue());
+			} else {
+				// This should never happen because we build that map only through our builders
+				throw new IllegalStateException("Illegal value inside extensions map: " + entry);
+			}
+		}
+	}
+
+	public static <T extends BinaryMessageVisitor<V>, V> V visit(CloudEvent cloudEvent, BinaryMessageVisitorFactory<T, V> visitorFactory)
+			throws MessageVisitException, IllegalStateException {
+		Attributes attributes = extractAttributes(cloudEvent);
+		BinaryMessageVisitor<V> visitor = visitorFactory.createBinaryMessageVisitor(extractAttributes(cloudEvent).getSpecVersion());
+		if (attributes instanceof BinaryMessageAttributes) {
+			((BinaryMessageAttributes)attributes).visitAttributes(visitor);
+			visitExtensions(cloudEvent, visitor);
+		}
+
+		if (cloudEvent.getData() != null) {
+			visitor.setBody(cloudEvent.getData());
+		}
+
+		return visitor.end();
+	}
+
+	@SuppressWarnings("rawtypes")
+	public static BinaryMessageVisitorFactory defaultBinaryMessageVisitorFactory() {
+		return specVersion -> {
+			switch (specVersion) {
+			case V1:
+				return CloudEventUtils.buildV1();
+			case V03:
+				return CloudEventUtils.buildV03();
+			default:
+				throw new IllegalStateException("Unrecognized spec version: " + specVersion);
+			}
+		};
+	}
+}

--- a/api/src/main/java/io/cloudevents/message/BinaryMessage.java
+++ b/api/src/main/java/io/cloudevents/message/BinaryMessage.java
@@ -18,6 +18,7 @@
 package io.cloudevents.message;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.impl.CloudEventUtils;
 
 @FunctionalInterface
 public interface BinaryMessage {
@@ -29,18 +30,9 @@ public interface BinaryMessage {
      */
     <V extends BinaryMessageVisitor<R>, R> R visit(BinaryMessageVisitorFactory<V, R> visitorFactory) throws MessageVisitException, IllegalStateException;
 
-    default CloudEvent toEvent() throws MessageVisitException, IllegalStateException {
-        return this.visit(specVersion -> {
-            switch (specVersion) {
-                case V1:
-                    return CloudEvent.buildV1();
-                case V03:
-                    return CloudEvent.buildV03();
-            }
-            return null; // This can never happen
-        });
-    }
-
-    ;
+    @SuppressWarnings("unchecked")
+	default CloudEvent toEvent() throws MessageVisitException, IllegalStateException {
+		return (CloudEvent) this.visit(CloudEventUtils.defaultBinaryMessageVisitorFactory());
+    };
 
 }

--- a/api/src/main/java/io/cloudevents/message/Message.java
+++ b/api/src/main/java/io/cloudevents/message/Message.java
@@ -19,6 +19,7 @@ package io.cloudevents.message;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.format.EventFormat;
+import io.cloudevents.impl.CloudEventUtils;
 
 public interface Message extends StructuredMessage, BinaryMessage {
 
@@ -35,18 +36,12 @@ public interface Message extends StructuredMessage, BinaryMessage {
         }
     }
 
-    default CloudEvent toEvent() throws MessageVisitException, IllegalStateException {
+    @SuppressWarnings("unchecked")
+	@Override
+	default CloudEvent toEvent() throws MessageVisitException, IllegalStateException {
         switch (getEncoding()) {
             case BINARY:
-                return this.visit(specVersion -> {
-                    switch (specVersion) {
-                        case V1:
-                            return CloudEvent.buildV1();
-                        case V03:
-                            return CloudEvent.buildV03();
-                    }
-                    return null; // This can never happen
-                });
+                return (CloudEvent) this.visit(CloudEventUtils.defaultBinaryMessageVisitorFactory());
             case STRUCTURED:
                 return this.visit(EventFormat::deserialize);
             default:

--- a/api/src/test/java/io/cloudevents/extensions/DistributedTracingExtensionTest.java
+++ b/api/src/test/java/io/cloudevents/extensions/DistributedTracingExtensionTest.java
@@ -17,6 +17,9 @@
 package io.cloudevents.extensions;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.impl.BaseCloudEventBuilder;
+import io.cloudevents.impl.CloudEventUtils;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,16 +35,17 @@ public class DistributedTracingExtensionTest {
         tracing.setTraceparent("parent");
         tracing.setTracestate("state");
 
-        CloudEvent event = CloudEvent.buildV1().withExtension(tracing).build();
+        CloudEvent event = CloudEventUtils.buildV1().withExtension(tracing).build();
 
         assertThat(event.getExtensions())
             .containsEntry(DistributedTracingExtension.TRACEPARENT, "parent")
             .containsEntry(DistributedTracingExtension.TRACESTATE, "state");
     }
 
-    @Test
-    public void parseExtension() {
-        CloudEvent event = CloudEvent.buildV1()
+
+	@Test
+	public void parseExtension() {
+        CloudEvent event = CloudEventUtils.buildV1()
             .withExtension(DistributedTracingExtension.TRACEPARENT, "parent")
             .withExtension(DistributedTracingExtension.TRACESTATE, "state")
             .build();

--- a/api/src/test/java/io/cloudevents/impl/CloudEventImplTest.java
+++ b/api/src/test/java/io/cloudevents/impl/CloudEventImplTest.java
@@ -27,7 +27,7 @@ public class CloudEventImplTest {
 
     @Test
     public void testEqualityV03() {
-        CloudEvent event1 = CloudEvent.buildV03()
+        CloudEvent event1 = CloudEventUtils.buildV03()
             .withId(ID)
             .withType(TYPE)
             .withSource(SOURCE)
@@ -36,7 +36,7 @@ public class CloudEventImplTest {
             .withTime(TIME)
             .build();
 
-        CloudEvent event2 = CloudEvent.buildV03()
+        CloudEvent event2 = CloudEventUtils.buildV03()
             .withId(ID)
             .withType(TYPE)
             .withSource(SOURCE)
@@ -50,7 +50,7 @@ public class CloudEventImplTest {
 
     @Test
     public void testEqualityV1() {
-        CloudEvent event1 = CloudEvent.buildV1()
+        CloudEvent event1 = CloudEventUtils.buildV1()
             .withId(ID)
             .withType(TYPE)
             .withSource(SOURCE)
@@ -59,7 +59,7 @@ public class CloudEventImplTest {
             .withTime(TIME)
             .build();
 
-        CloudEvent event2 = CloudEvent.buildV1()
+        CloudEvent event2 = CloudEventUtils.buildV1()
             .withId(ID)
             .withType(TYPE)
             .withSource(SOURCE)

--- a/api/src/test/java/io/cloudevents/message/EventMessageRoundtripTest.java
+++ b/api/src/test/java/io/cloudevents/message/EventMessageRoundtripTest.java
@@ -18,6 +18,7 @@
 package io.cloudevents.message;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.impl.CloudEventUtils;
 import io.cloudevents.mock.CSVFormat;
 import io.cloudevents.mock.MockBinaryMessage;
 import io.cloudevents.mock.MockStructuredMessage;
@@ -36,7 +37,7 @@ public class EventMessageRoundtripTest {
     @ParameterizedTest()
     @MethodSource("io.cloudevents.test.Data#allEventsWithoutExtensions")
     void structuredToEvent(CloudEvent input) {
-        assertThat(input.asStructuredMessage(CSVFormat.INSTANCE).toEvent())
+        assertThat(CloudEventUtils.asStructuredMessage(input, CSVFormat.INSTANCE).toEvent())
             .isEqualTo(input);
     }
 
@@ -48,21 +49,21 @@ public class EventMessageRoundtripTest {
     @ParameterizedTest()
     @MethodSource("io.cloudevents.test.Data#allEventsWithoutExtensions")
     void structuredToMockStructuredMessageToEvent(CloudEvent input) {
-        assertThat(input.asStructuredMessage(CSVFormat.INSTANCE).visit(new MockStructuredMessage()).toEvent())
+        assertThat(CloudEventUtils.asStructuredMessage(input, CSVFormat.INSTANCE).visit(new MockStructuredMessage()).toEvent())
             .isEqualTo(input);
     }
 
     @ParameterizedTest()
     @MethodSource("io.cloudevents.test.Data#allEvents")
     void binaryToEvent(CloudEvent input) {
-        assertThat(input.asBinaryMessage().toEvent())
+        assertThat(CloudEventUtils.asBinaryMessage(input).toEvent())
             .isEqualTo(input);
     }
 
     @ParameterizedTest()
     @MethodSource("io.cloudevents.test.Data#allEvents")
     void binaryToMockBinaryMessageToEvent(CloudEvent input) {
-        assertThat(input.asBinaryMessage().visit(new MockBinaryMessage()).toEvent())
+        assertThat(CloudEventUtils.asBinaryMessage(input).visit(new MockBinaryMessage()).toEvent())
             .isEqualTo(input);
     }
 

--- a/api/src/test/java/io/cloudevents/mock/CSVFormat.java
+++ b/api/src/test/java/io/cloudevents/mock/CSVFormat.java
@@ -20,6 +20,7 @@ package io.cloudevents.mock;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.format.EventFormat;
+import io.cloudevents.impl.CloudEventUtils;
 import io.cloudevents.types.Time;
 import io.cloudevents.v1.CloudEventBuilder;
 
@@ -40,15 +41,15 @@ public class CSVFormat implements EventFormat {
     public byte[] serialize(CloudEvent event) {
         return String.join(
             ",",
-            event.getAttributes().getSpecVersion().toString(),
-            event.getAttributes().getId(),
-            event.getAttributes().getType(),
-            event.getAttributes().getSource().toString(),
-            Objects.toString(event.getAttributes().getDataContentType()),
-            Objects.toString(event.getAttributes().getDataSchema()),
-            Objects.toString(event.getAttributes().getSubject()),
-            event.getAttributes().getTime() != null
-                ? Time.RFC3339_DATE_FORMAT.format(event.getAttributes().getTime())
+            event.getSpecVersion().toString(),
+            event.getId(),
+            event.getType(),
+            event.getSource().toString(),
+            Objects.toString(event.getDataContentType()),
+            Objects.toString(event.getDataSchema()),
+            Objects.toString(event.getSubject()),
+            event.getTime() != null
+                ? Time.RFC3339_DATE_FORMAT.format(event.getTime())
                 : "null",
             event.getData() != null
                 ? new String(Base64.getEncoder().encode(event.getData()), StandardCharsets.UTF_8)
@@ -70,7 +71,7 @@ public class CSVFormat implements EventFormat {
         ZonedDateTime time = splitted[7].equals("null") ? null : Time.parseTime(splitted[7]);
         byte[] data = splitted[8].equals("null") ? null : Base64.getDecoder().decode(splitted[8].getBytes());
 
-        CloudEventBuilder builder = CloudEvent.buildV1()
+        CloudEventBuilder builder = CloudEventUtils.buildV1()
             .withId(id)
             .withType(type)
             .withSource(source);
@@ -90,12 +91,12 @@ public class CSVFormat implements EventFormat {
         if (data != null) {
             builder.withData(data);
         }
-        switch (sv) {
-            case V03:
-                return builder.build().toV03();
-            case V1:
-                return builder.build().toV1();
-        }
+		switch (sv) {
+			case V03:
+				return CloudEventUtils.toV03(builder.build());
+			case V1:
+				return CloudEventUtils.toV1(builder.build());
+		}
         return null;
     }
 

--- a/api/src/test/java/io/cloudevents/test/Data.java
+++ b/api/src/test/java/io/cloudevents/test/Data.java
@@ -17,12 +17,13 @@
 
 package io.cloudevents.test;
 
-import io.cloudevents.CloudEvent;
-import io.cloudevents.types.Time;
-
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.stream.Stream;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.impl.CloudEventUtils;
+import io.cloudevents.types.Time;
 
 public class Data {
 
@@ -40,13 +41,13 @@ public class Data {
     public static byte[] DATA_XML_SERIALIZED = "<stuff></stuff>".getBytes();
     public static byte[] DATA_TEXT_SERIALIZED = "Hello World Lorena!".getBytes();
 
-    public static final CloudEvent V1_MIN = CloudEvent.buildV1()
+    public static final CloudEvent V1_MIN = CloudEventUtils.buildV1()
         .withId(ID)
         .withType(TYPE)
         .withSource(SOURCE)
         .build();
 
-    public static final CloudEvent V1_WITH_JSON_DATA = CloudEvent.buildV1()
+    public static final CloudEvent V1_WITH_JSON_DATA = CloudEventUtils.buildV1()
         .withId(ID)
         .withType(TYPE)
         .withSource(SOURCE)
@@ -55,7 +56,7 @@ public class Data {
         .withTime(TIME)
         .build();
 
-    public static final CloudEvent V1_WITH_JSON_DATA_WITH_EXT = CloudEvent.buildV1()
+    public static final CloudEvent V1_WITH_JSON_DATA_WITH_EXT = CloudEventUtils.buildV1()
         .withId(ID)
         .withType(TYPE)
         .withSource(SOURCE)
@@ -67,7 +68,7 @@ public class Data {
         .withExtension("anumber", 10)
         .build();
 
-    public static final CloudEvent V1_WITH_JSON_DATA_WITH_EXT_STRING = CloudEvent.buildV1()
+    public static final CloudEvent V1_WITH_JSON_DATA_WITH_EXT_STRING = CloudEventUtils.buildV1()
         .withId(ID)
         .withType(TYPE)
         .withSource(SOURCE)
@@ -79,7 +80,7 @@ public class Data {
         .withExtension("anumber", "10")
         .build();
 
-    public static final CloudEvent V1_WITH_XML_DATA = CloudEvent.buildV1()
+    public static final CloudEvent V1_WITH_XML_DATA = CloudEventUtils.buildV1()
         .withId(ID)
         .withType(TYPE)
         .withSource(SOURCE)
@@ -88,7 +89,7 @@ public class Data {
         .withTime(TIME)
         .build();
 
-    public static final CloudEvent V1_WITH_TEXT_DATA = CloudEvent.buildV1()
+    public static final CloudEvent V1_WITH_TEXT_DATA = CloudEventUtils.buildV1()
         .withId(ID)
         .withType(TYPE)
         .withSource(SOURCE)
@@ -97,12 +98,12 @@ public class Data {
         .withTime(TIME)
         .build();
 
-    public static final CloudEvent V03_MIN = V1_MIN.toV03();
-    public static final CloudEvent V03_WITH_JSON_DATA = V1_WITH_JSON_DATA.toV03();
-    public static final CloudEvent V03_WITH_JSON_DATA_WITH_EXT = V1_WITH_JSON_DATA_WITH_EXT.toV03();
-    public static final CloudEvent V03_WITH_JSON_DATA_WITH_EXT_STRING = V1_WITH_JSON_DATA_WITH_EXT_STRING.toV03();
-    public static final CloudEvent V03_WITH_XML_DATA = V1_WITH_XML_DATA.toV03();
-    public static final CloudEvent V03_WITH_TEXT_DATA = V1_WITH_TEXT_DATA.toV03();
+    public static final CloudEvent V03_MIN = CloudEventUtils.toV03(V1_MIN);
+    public static final CloudEvent V03_WITH_JSON_DATA = CloudEventUtils.toV03(V1_WITH_JSON_DATA);
+    public static final CloudEvent V03_WITH_JSON_DATA_WITH_EXT =  CloudEventUtils.toV03(V1_WITH_JSON_DATA_WITH_EXT);
+    public static final CloudEvent V03_WITH_JSON_DATA_WITH_EXT_STRING = CloudEventUtils.toV03(V1_WITH_JSON_DATA_WITH_EXT_STRING);
+    public static final CloudEvent V03_WITH_XML_DATA = CloudEventUtils.toV03(V1_WITH_XML_DATA);
+    public static final CloudEvent V03_WITH_TEXT_DATA = CloudEventUtils.toV03(V1_WITH_TEXT_DATA);
 
     public static Stream<CloudEvent> allEvents() {
         return Stream.concat(v1Events(), v03Events());
@@ -138,7 +139,7 @@ public class Data {
 
     public static Stream<CloudEvent> v1EventsWithStringExt() {
         return v1Events().map(ce -> {
-            io.cloudevents.v1.CloudEventBuilder builder = CloudEvent.buildV1(ce);
+            io.cloudevents.v1.CloudEventBuilder builder = CloudEventUtils.buildV1(ce);
             ce.getExtensions().forEach((k, v) -> builder.withExtension(k, v.toString()));
             return builder.build();
         });
@@ -146,7 +147,7 @@ public class Data {
 
     public static Stream<CloudEvent> v03EventsWithStringExt() {
         return v03Events().map(ce -> {
-            io.cloudevents.v03.CloudEventBuilder builder = CloudEvent.buildV03(ce);
+            io.cloudevents.v03.CloudEventBuilder builder = CloudEventUtils.buildV03(ce);
             ce.getExtensions().forEach((k, v) -> builder.withExtension(k, v.toString()));
             return builder.build();
         });

--- a/api/src/test/java/io/cloudevents/v03/CloudEventBuilderTest.java
+++ b/api/src/test/java/io/cloudevents/v03/CloudEventBuilderTest.java
@@ -18,6 +18,8 @@ package io.cloudevents.v03;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.impl.CloudEventUtils;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -31,18 +33,18 @@ public class CloudEventBuilderTest {
     @ParameterizedTest()
     @MethodSource("io.cloudevents.test.Data#v03Events")
     void testCopyWithBuilder(CloudEvent event) {
-        assertThat(CloudEvent.buildV03(event).build()).isEqualTo(event);
+        assertThat(CloudEventUtils.buildV03(event).build()).isEqualTo(event);
     }
 
     @ParameterizedTest()
     @MethodSource("io.cloudevents.test.Data#v03Events")
     void testToV1(CloudEvent event) {
-        CloudEvent eventV1 = CloudEvent.buildV1(event).build();
+        CloudEvent eventV1 = CloudEventUtils.buildV1(event).build();
 
-        assertThat(eventV1.getAttributes().getSpecVersion())
+        assertThat(eventV1.getSpecVersion())
             .isEqualTo(SpecVersion.V1);
 
-        assertThat(eventV1).isEqualTo(event.toV1());
+        assertThat(eventV1).isEqualTo(CloudEventUtils.toV1(event));
     }
 
 }

--- a/api/src/test/java/io/cloudevents/v1/CloudEventBuilderTest.java
+++ b/api/src/test/java/io/cloudevents/v1/CloudEventBuilderTest.java
@@ -18,6 +18,9 @@ package io.cloudevents.v1;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.impl.CloudEventImpl;
+import io.cloudevents.impl.CloudEventUtils;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -32,18 +35,18 @@ public class CloudEventBuilderTest {
     @ParameterizedTest()
     @MethodSource("io.cloudevents.test.Data#v1Events")
     void testCopyWithBuilder(CloudEvent event) {
-        assertThat(CloudEvent.buildV1(event).build()).isEqualTo(event);
+        assertThat(CloudEventUtils.buildV1(event).build()).isEqualTo(event);
     }
 
     @ParameterizedTest()
     @MethodSource("io.cloudevents.test.Data#v1Events")
     void testToV03(CloudEvent event) {
-        CloudEvent eventV03 = CloudEvent.buildV03(event).build();
+        CloudEvent eventV03 = CloudEventUtils.buildV03(event).build();
 
-        assertThat(eventV03.getAttributes().getSpecVersion())
+        assertThat(eventV03.getSpecVersion())
             .isEqualTo(SpecVersion.V03);
 
-        assertThat(eventV03).isEqualTo(event.toV03());
+        assertThat(eventV03).isEqualTo(CloudEventUtils.toV03((CloudEventImpl) event));
     }
 
 }

--- a/http/vertx/src/test/java/io/cloudevents/http/vertx/VertxHttpClientRequestMessageVisitorTest.java
+++ b/http/vertx/src/test/java/io/cloudevents/http/vertx/VertxHttpClientRequestMessageVisitorTest.java
@@ -19,6 +19,7 @@ package io.cloudevents.http.vertx;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.impl.CloudEventUtils;
 import io.cloudevents.mock.CSVFormat;
 import io.cloudevents.types.Time;
 import io.vertx.core.MultiMap;
@@ -73,12 +74,12 @@ public class VertxHttpClientRequestMessageVisitorTest {
                     });
                     checkpoint.flag();
                 });
-                try {
-                    event.asStructuredMessage(CSVFormat.INSTANCE)
-                        .visit(VertxHttpClientRequestMessageVisitor.create(req));
-                } catch (Throwable e) {
-                    testContext.failNow(e);
-                }
+				try {
+					CloudEventUtils.asStructuredMessage(event, CSVFormat.INSTANCE)
+							.visit(VertxHttpClientRequestMessageVisitor.create(req));
+				} catch (Throwable e) {
+					testContext.failNow(e);
+				}
                 checkpoint.flag();
             }));
     }
@@ -115,12 +116,11 @@ public class VertxHttpClientRequestMessageVisitorTest {
                     });
                     checkpoint.flag();
                 });
-                try {
-                    event.asBinaryMessage()
-                        .visit(VertxHttpClientRequestMessageVisitor.create(req));
-                } catch (Throwable e) {
-                    testContext.failNow(e);
-                }
+				try {
+					CloudEventUtils.asBinaryMessage(event).visit(VertxHttpClientRequestMessageVisitor.create(req));
+				} catch (Throwable e) {
+					testContext.failNow(e);
+				}
                 checkpoint.flag();
             }));
     }

--- a/http/vertx/src/test/java/io/cloudevents/http/vertx/VertxHttpServerResponseMessageVisitorTest.java
+++ b/http/vertx/src/test/java/io/cloudevents/http/vertx/VertxHttpServerResponseMessageVisitorTest.java
@@ -19,6 +19,7 @@ package io.cloudevents.http.vertx;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.impl.CloudEventUtils;
 import io.cloudevents.mock.CSVFormat;
 import io.cloudevents.types.Time;
 import io.vertx.core.MultiMap;
@@ -50,7 +51,7 @@ public class VertxHttpServerResponseMessageVisitorTest {
             .createHttpServer()
             .requestHandler(httpServerRequest -> {
                 try {
-                    event.asStructuredMessage(CSVFormat.INSTANCE).visit(
+                    CloudEventUtils.asStructuredMessage(event, CSVFormat.INSTANCE).visit(
                         VertxHttpServerResponseMessageVisitor.create(httpServerRequest.response())
                     );
                     checkpoint.flag();
@@ -89,7 +90,7 @@ public class VertxHttpServerResponseMessageVisitorTest {
             .createHttpServer()
             .requestHandler(httpServerRequest -> {
                 try {
-                    event.asBinaryMessage().visit(
+                    CloudEventUtils.asBinaryMessage(event).visit(
                         VertxHttpServerResponseMessageVisitor.create(httpServerRequest.response())
                     );
                     checkpoint.flag();

--- a/kafka/src/main/java/io/cloudevents/kafka/CloudEventSerializer.java
+++ b/kafka/src/main/java/io/cloudevents/kafka/CloudEventSerializer.java
@@ -20,6 +20,7 @@ package io.cloudevents.kafka;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.format.EventFormat;
 import io.cloudevents.format.EventFormatProvider;
+import io.cloudevents.impl.CloudEventUtils;
 import io.cloudevents.kafka.impl.KafkaSerializerMessageVisitorImpl;
 import io.cloudevents.message.Encoding;
 import org.apache.kafka.common.header.Headers;
@@ -83,9 +84,9 @@ public class CloudEventSerializer implements Serializer<CloudEvent> {
     @Override
     public byte[] serialize(String topic, Headers headers, CloudEvent data) {
         if (encoding == Encoding.STRUCTURED) {
-            return data.asStructuredMessage(this.format).visit(new KafkaSerializerMessageVisitorImpl(headers));
+            return CloudEventUtils.asStructuredMessage(data, this.format).visit(new KafkaSerializerMessageVisitorImpl(headers));
         } else {
-            return data.asBinaryMessage().visit(new KafkaSerializerMessageVisitorImpl(headers));
+            return CloudEventUtils.asBinaryMessage(data).visit(new KafkaSerializerMessageVisitorImpl(headers));
         }
     }
 }

--- a/kafka/src/test/java/io/cloudevents/kafka/CloudEventDeserializerTest.java
+++ b/kafka/src/test/java/io/cloudevents/kafka/CloudEventDeserializerTest.java
@@ -18,6 +18,7 @@
 package io.cloudevents.kafka;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.impl.CloudEventUtils;
 import io.cloudevents.test.Data;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ public class CloudEventDeserializerTest {
         CloudEventDeserializer deserializer = new CloudEventDeserializer();
 
         // Serialize the event first
-        ProducerRecord<Void, byte[]> inRecord = inEvent.asBinaryMessage().visit(KafkaProducerMessageVisitor.create(topic));
+        ProducerRecord<Void, byte[]> inRecord = CloudEventUtils.asBinaryMessage(inEvent).visit(KafkaProducerMessageVisitor.create(topic));
         CloudEvent outEvent = deserializer.deserialize(topic, inRecord.headers(), inRecord.value());
 
         assertThat(outEvent)

--- a/kafka/src/test/java/io/cloudevents/kafka/CloudEventMessageDeserializerTest.java
+++ b/kafka/src/test/java/io/cloudevents/kafka/CloudEventMessageDeserializerTest.java
@@ -18,6 +18,7 @@
 package io.cloudevents.kafka;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.impl.CloudEventUtils;
 import io.cloudevents.message.Encoding;
 import io.cloudevents.message.Message;
 import io.cloudevents.test.Data;
@@ -36,7 +37,7 @@ public class CloudEventMessageDeserializerTest {
         CloudEventMessageDeserializer deserializer = new CloudEventMessageDeserializer();
 
         // Serialize the event first
-        ProducerRecord<Void, byte[]> inRecord = inEvent.asBinaryMessage().visit(KafkaProducerMessageVisitor.create(topic));
+        ProducerRecord<Void, byte[]> inRecord = CloudEventUtils.asBinaryMessage(inEvent).visit(KafkaProducerMessageVisitor.create(topic));
         Message outMessage = deserializer.deserialize(topic, inRecord.headers(), inRecord.value());
 
         assertThat(outMessage.getEncoding())

--- a/kafka/src/test/java/io/cloudevents/kafka/CloudEventMessageSerializerTest.java
+++ b/kafka/src/test/java/io/cloudevents/kafka/CloudEventMessageSerializerTest.java
@@ -18,6 +18,7 @@
 package io.cloudevents.kafka;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.impl.CloudEventUtils;
 import io.cloudevents.message.Encoding;
 import io.cloudevents.message.Message;
 import io.cloudevents.mock.MockBinaryMessage;
@@ -40,7 +41,7 @@ public class CloudEventMessageSerializerTest {
         Headers headers = new RecordHeaders();
 
         MockBinaryMessage inMessage = new MockBinaryMessage();
-        event.asBinaryMessage().visit(inMessage);
+        CloudEventUtils.asBinaryMessage(event).visit(inMessage);
 
         byte[] payload = serializer.serialize(topic, headers, inMessage);
 

--- a/kafka/src/test/java/io/cloudevents/kafka/KafkaProducerMessageVisitorTest.java
+++ b/kafka/src/test/java/io/cloudevents/kafka/KafkaProducerMessageVisitorTest.java
@@ -19,6 +19,7 @@ package io.cloudevents.kafka;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.impl.CloudEventUtils;
 import io.cloudevents.kafka.impl.KafkaHeaders;
 import io.cloudevents.mock.CSVFormat;
 import io.cloudevents.types.Time;
@@ -49,8 +50,8 @@ public class KafkaProducerMessageVisitorTest {
         Long timestamp = System.currentTimeMillis();
         String key = "aaa";
 
-        ProducerRecord<String, byte[]> producerRecord = event
-            .asStructuredMessage(CSVFormat.INSTANCE)
+        ProducerRecord<String, byte[]> producerRecord =
+            CloudEventUtils.asStructuredMessage(event, CSVFormat.INSTANCE)
             .visit(KafkaProducerMessageVisitor.create(topic, partition, timestamp, key));
 
         assertThat(producerRecord.topic())
@@ -75,8 +76,8 @@ public class KafkaProducerMessageVisitorTest {
         Long timestamp = System.currentTimeMillis();
         String key = "aaa";
 
-        ProducerRecord<String, byte[]> producerRecord = event
-            .asBinaryMessage()
+        ProducerRecord<String, byte[]> producerRecord =
+        	CloudEventUtils.asBinaryMessage(event)
             .visit(KafkaProducerMessageVisitor.create(topic, partition, timestamp, key));
 
         assertThat(producerRecord.topic())


### PR DESCRIPTION
- Streamlined CloudEvent strategy to ensure it's clean from any assumptions on possible implementation details to ensure that CloudEvent
type created outside of SDK is just as valid and operable as the one created by SDK.
- Created CloudEventUtils as general utility class to contain set of static method to manipulate various aspects of CloudEvent. Factory
methods that were previosuly in CloudEvent as well as other interafces were moved. Tests and other implementations were adjusted accordingly.
- Cleaned up logic in Message and BinaryMessage related to 'can never happen` comment as well as fixing compilation errors these classes were generating in some IDEs.

Signed-off-by: Oleg Zhurakousky <ozhurakousky@pivotal.io>