### PR TITLE
Reworked a bit the Extension interface

### DIFF
--- a/api/src/main/java/io/cloudevents/Extension.java
+++ b/api/src/main/java/io/cloudevents/Extension.java
@@ -40,7 +40,7 @@ public interface Extension {
      *
      * @param key the name of the extension attribute
      * @return the extension value
-     * @throws IllegalArgumentException if the key is not a valid attribute key for this extension
+     * @throws IllegalArgumentException if the key is unknown to this extension
      */
     @Nullable
     Object getValue(String key) throws IllegalArgumentException;

--- a/api/src/main/java/io/cloudevents/Extension.java
+++ b/api/src/main/java/io/cloudevents/Extension.java
@@ -27,6 +27,6 @@ public interface Extension extends CloudEventExtensions {
      *
      * @param extensions
      */
-    void readFromEvent(CloudEventExtensions extensions);
+    void readFrom(CloudEventExtensions extensions);
 
 }

--- a/api/src/main/java/io/cloudevents/Extension.java
+++ b/api/src/main/java/io/cloudevents/Extension.java
@@ -17,10 +17,16 @@
 
 package io.cloudevents;
 
+import io.cloudevents.lang.Nullable;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Set;
+
 /**
  * Materialized CloudEvent Extension interface to read/write the extension attributes key/values.
  */
-public interface Extension extends CloudEventExtensions {
+@ParametersAreNonnullByDefault
+public interface Extension {
 
     /**
      * Fill this materialized extension with values from a {@link CloudEventExtensions} implementation
@@ -28,5 +34,21 @@ public interface Extension extends CloudEventExtensions {
      * @param extensions
      */
     void readFrom(CloudEventExtensions extensions);
+
+    /**
+     * Get the attribute of extension named {@code key}
+     *
+     * @param key the name of the extension attribute
+     * @return the extension value
+     */
+    @Nullable
+    Object getValue(String key);
+
+    /**
+     * Get the set of possible extension attribute keys
+     *
+     * @return set of possible extension attribute keys
+     */
+    Set<String> getKeys();
 
 }

--- a/api/src/main/java/io/cloudevents/Extension.java
+++ b/api/src/main/java/io/cloudevents/Extension.java
@@ -40,9 +40,10 @@ public interface Extension {
      *
      * @param key the name of the extension attribute
      * @return the extension value
+     * @throws IllegalArgumentException if the key is not a valid attribute key for this extension
      */
     @Nullable
-    Object getValue(String key);
+    Object getValue(String key) throws IllegalArgumentException;
 
     /**
      * Get the set of possible extension attribute keys

--- a/api/src/main/java/io/cloudevents/Extension.java
+++ b/api/src/main/java/io/cloudevents/Extension.java
@@ -17,12 +17,16 @@
 
 package io.cloudevents;
 
-import java.util.Map;
+/**
+ * Materialized CloudEvent Extension interface to read/write the extension attributes key/values.
+ */
+public interface Extension extends CloudEventExtensions {
 
-public interface Extension {
-
-    void readFromEvent(CloudEvent event);
-
-    Map<String, Object> asMap();
+    /**
+     * Fill this materialized extension with values from a {@link CloudEventExtensions} implementation
+     *
+     * @param extensions
+     */
+    void readFromEvent(CloudEventExtensions extensions);
 
 }

--- a/core/src/main/java/io/cloudevents/core/extensions/DistributedTracingExtension.java
+++ b/core/src/main/java/io/cloudevents/core/extensions/DistributedTracingExtension.java
@@ -63,7 +63,7 @@ public final class DistributedTracingExtension implements Extension {
     }
 
     @Override
-    public Object getExtension(String extensionName) {
+    public Object getValue(String extensionName) {
         switch (extensionName) {
             case TRACEPARENT:
                 return this.traceparent;
@@ -74,7 +74,7 @@ public final class DistributedTracingExtension implements Extension {
     }
 
     @Override
-    public Set<String> getExtensionNames() {
+    public Set<String> getKeys() {
         return KEY_SET;
     }
 

--- a/core/src/main/java/io/cloudevents/core/extensions/DistributedTracingExtension.java
+++ b/core/src/main/java/io/cloudevents/core/extensions/DistributedTracingExtension.java
@@ -17,17 +17,19 @@
 
 package io.cloudevents.core.extensions;
 
-import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventExtensions;
 import io.cloudevents.Extension;
 
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 public final class DistributedTracingExtension implements Extension {
 
     public static final String TRACEPARENT = "traceparent";
     public static final String TRACESTATE = "tracestate";
+    private static final Set<String> KEY_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(TRACEPARENT, TRACESTATE)));
 
     private String traceparent;
     private String tracestate;
@@ -49,23 +51,31 @@ public final class DistributedTracingExtension implements Extension {
     }
 
     @Override
-    public void readFromEvent(CloudEvent event) {
-        Object tp = event.getExtension(TRACEPARENT);
+    public void readFromEvent(CloudEventExtensions extensions) {
+        Object tp = extensions.getExtension(TRACEPARENT);
         if (tp != null) {
             this.traceparent = tp.toString();
         }
-        Object ts = event.getExtension(TRACESTATE);
+        Object ts = extensions.getExtension(TRACESTATE);
         if (ts != null) {
             this.tracestate = ts.toString();
         }
     }
 
     @Override
-    public Map<String, Object> asMap() {
-        HashMap<String, Object> map = new HashMap<>();
-        map.put(TRACEPARENT, this.traceparent);
-        map.put(TRACESTATE, this.tracestate);
-        return Collections.unmodifiableMap(map);
+    public Object getExtension(String extensionName) {
+        switch (extensionName) {
+            case TRACEPARENT:
+                return this.traceparent;
+            case TRACESTATE:
+                return this.tracestate;
+        }
+        return null;
+    }
+
+    @Override
+    public Set<String> getExtensionNames() {
+        return KEY_SET;
     }
 
     @Override

--- a/core/src/main/java/io/cloudevents/core/extensions/DistributedTracingExtension.java
+++ b/core/src/main/java/io/cloudevents/core/extensions/DistributedTracingExtension.java
@@ -19,6 +19,7 @@ package io.cloudevents.core.extensions;
 
 import io.cloudevents.CloudEventExtensions;
 import io.cloudevents.Extension;
+import io.cloudevents.core.extensions.impl.ExtensionUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -63,14 +64,14 @@ public final class DistributedTracingExtension implements Extension {
     }
 
     @Override
-    public Object getValue(String extensionName) {
-        switch (extensionName) {
+    public Object getValue(String key) {
+        switch (key) {
             case TRACEPARENT:
                 return this.traceparent;
             case TRACESTATE:
                 return this.tracestate;
         }
-        return null;
+        throw ExtensionUtils.generateInvalidKeyException(this.getClass().getSimpleName(), key);
     }
 
     @Override

--- a/core/src/main/java/io/cloudevents/core/extensions/DistributedTracingExtension.java
+++ b/core/src/main/java/io/cloudevents/core/extensions/DistributedTracingExtension.java
@@ -51,7 +51,7 @@ public final class DistributedTracingExtension implements Extension {
     }
 
     @Override
-    public void readFromEvent(CloudEventExtensions extensions) {
+    public void readFrom(CloudEventExtensions extensions) {
         Object tp = extensions.getExtension(TRACEPARENT);
         if (tp != null) {
             this.traceparent = tp.toString();

--- a/core/src/main/java/io/cloudevents/core/extensions/ExtensionsParser.java
+++ b/core/src/main/java/io/cloudevents/core/extensions/ExtensionsParser.java
@@ -51,7 +51,7 @@ public final class ExtensionsParser {
         Supplier<Extension> factory = extensionFactories.get(extensionClass);
         if (factory != null) {
             Extension ext = factory.get();
-            ext.readFromEvent(event);
+            ext.readFrom(event);
             return (T) ext;
         }
         return null;

--- a/core/src/main/java/io/cloudevents/core/extensions/impl/ExtensionUtils.java
+++ b/core/src/main/java/io/cloudevents/core/extensions/impl/ExtensionUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.core.extensions.impl;
+
+public final class ExtensionUtils {
+
+    private ExtensionUtils() {
+    }
+
+    public static IllegalArgumentException generateInvalidKeyException(String extensionName, String key) {
+        return new IllegalArgumentException(extensionName + " doesn't expect the attribute key \"" + key + "\"");
+    }
+
+}

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -95,7 +95,12 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     }
 
     public SELF withExtension(Extension extension) {
-        this.extensions.putAll(extension.asMap());
+        for (String key : extension.getExtensionNames()) {
+            Object value = extension.getExtension(key);
+            if (value != null) {
+                this.extensions.put(key, value);
+            }
+        }
         return self;
     }
 

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -95,8 +95,8 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     }
 
     public SELF withExtension(Extension extension) {
-        for (String key : extension.getExtensionNames()) {
-            Object value = extension.getExtension(key);
+        for (String key : extension.getKeys()) {
+            Object value = extension.getValue(key);
             if (value != null) {
                 this.extensions.put(key, value);
             }


### PR DESCRIPTION
Look at #122

This change:

* Change the signature of `readFromEvent` to accept `CloudEventExtensions`
* Remove `asMap()` and let `Extension` extend `CloudEventExtensions`. Because the number of attributes for a materialized extension is always the same, allocating a map to provide an unstructrured view (needed to write the materialized extension to the cloud event builder) is useless. This solution makes more efficient the implementation of such materialized extensions

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>