### PR TITLE
CloudEventBuilder interface now has withAttribute methods

### DIFF
--- a/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
@@ -18,12 +18,43 @@
 package io.cloudevents.core.builder;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.Extension;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.visitor.CloudEventVisitor;
 
 import javax.annotation.Nonnull;
+import java.net.URI;
+import java.time.ZonedDateTime;
 
 public interface CloudEventBuilder extends CloudEventVisitor<CloudEvent> {
+
+    CloudEventBuilder withId(String id);
+
+    CloudEventBuilder withSource(URI source);
+
+    CloudEventBuilder withType(String type);
+
+    CloudEventBuilder withDataSchema(URI dataschema);
+
+    CloudEventBuilder withDataContentType(String datacontenttype);
+
+    CloudEventBuilder withSubject(String subject);
+
+    CloudEventBuilder withTime(ZonedDateTime time);
+
+    CloudEventBuilder withData(byte[] data);
+
+    CloudEventBuilder withData(String contentType, byte[] data);
+
+    CloudEventBuilder withData(String contentType, URI dataSchema, byte[] data);
+
+    CloudEventBuilder withExtension(String key, String value);
+
+    CloudEventBuilder withExtension(String key, Number value);
+
+    CloudEventBuilder withExtension(String key, boolean value);
+
+    CloudEventBuilder withExtension(Extension extension);
 
     CloudEvent build();
 
@@ -44,6 +75,9 @@ public interface CloudEventBuilder extends CloudEventVisitor<CloudEvent> {
     }
 
     static CloudEventBuilder fromSpecVersion(@Nonnull SpecVersion version) {
+
+        io.cloudevents.core.v1.CloudEventBuilder v1 = v1().withId("aaaa");
+
         switch (version) {
             case V1:
                 return CloudEventBuilder.v1();

--- a/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
@@ -26,58 +26,174 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.time.ZonedDateTime;
 
+/**
+ * Builder interface to build a {@link CloudEvent}.
+ */
 public interface CloudEventBuilder extends CloudEventVisitor<CloudEvent> {
 
+    /**
+     * Set the {@code id} of the event
+     *
+     * @param id id of the event
+     * @return self
+     */
     CloudEventBuilder withId(String id);
 
+    /**
+     * Set the {@code source} of the event
+     *
+     * @param source source of the event
+     * @return self
+     */
     CloudEventBuilder withSource(URI source);
 
+    /**
+     * Set the {@code type} of the event
+     *
+     * @param type type of the event
+     * @return self
+     */
     CloudEventBuilder withType(String type);
 
-    CloudEventBuilder withDataSchema(URI dataschema);
+    /**
+     * Set the {@code dataschema} of the event. For CloudEvent v0.3, this will configure the {@code schemaurl} attribute.
+     *
+     * @param dataSchema dataschema of the event
+     * @return self
+     */
+    CloudEventBuilder withDataSchema(URI dataSchema);
 
-    CloudEventBuilder withDataContentType(String datacontenttype);
+    /**
+     * Set the {@code datacontenttype} of the event
+     *
+     * @param dataContentType datacontenttype of the event
+     * @return self
+     */
+    CloudEventBuilder withDataContentType(String dataContentType);
 
+    /**
+     * Set the {@code subject} of the event
+     *
+     * @param subject subject of the event
+     * @return self
+     */
     CloudEventBuilder withSubject(String subject);
 
+    /**
+     * Set the {@code time} of the event
+     *
+     * @param time time of the event
+     * @return self
+     */
     CloudEventBuilder withTime(ZonedDateTime time);
 
+    /**
+     * Set the {@code data} of the event
+     *
+     * @param data data of the event
+     * @return self
+     */
     CloudEventBuilder withData(byte[] data);
 
-    CloudEventBuilder withData(String contentType, byte[] data);
+    /**
+     * Set the {@code datacontenttype} and {@code data} of the event
+     *
+     * @param dataContentType datacontenttype of the event
+     * @param data            data of the event
+     * @return self
+     */
+    CloudEventBuilder withData(String dataContentType, byte[] data);
 
-    CloudEventBuilder withData(String contentType, URI dataSchema, byte[] data);
+    /**
+     * Set the {@code datacontenttype}, {@code dataschema} and {@code data} of the event
+     *
+     * @param dataContentType datacontenttype of the event
+     * @param dataSchema      dataschema of the event
+     * @param data            data of the event
+     * @return self
+     */
+    CloudEventBuilder withData(String dataContentType, URI dataSchema, byte[] data);
 
+    /**
+     * Set an extension with provided key and string value
+     *
+     * @param key   key of the extension attribute
+     * @param value value of the extension attribute
+     * @return self
+     */
     CloudEventBuilder withExtension(String key, String value);
 
+    /**
+     * Set an extension with provided key and numeric value
+     *
+     * @param key   key of the extension attribute
+     * @param value value of the extension attribute
+     * @return self
+     */
     CloudEventBuilder withExtension(String key, Number value);
 
+    /**
+     * Set an extension with provided key and boolean value
+     *
+     * @param key   key of the extension attribute
+     * @param value value of the extension attribute
+     * @return self
+     */
     CloudEventBuilder withExtension(String key, boolean value);
 
+    /**
+     * Add to the builder all the extension key/values of the provided extension
+     *
+     * @param extension materialized extension to set in the event
+     * @return self
+     */
     CloudEventBuilder withExtension(Extension extension);
 
-    CloudEvent build();
+    /**
+     * Build the event
+     *
+     * @return the built event
+     * @throws IllegalStateException if a required attribute is not configured
+     */
+    CloudEvent build() throws IllegalStateException;
 
+    /**
+     * @return a new CloudEvent v1 builder
+     */
     static io.cloudevents.core.v1.CloudEventBuilder v1() {
         return new io.cloudevents.core.v1.CloudEventBuilder();
     }
 
+    /**
+     * @param event event to bootstrap the builder
+     * @return a new CloudEvent v1 builder filled with content of {@code event}
+     */
     static io.cloudevents.core.v1.CloudEventBuilder v1(CloudEvent event) {
         return new io.cloudevents.core.v1.CloudEventBuilder(event);
     }
 
+    /**
+     * @return a new CloudEvent v0.3 builder
+     */
     static io.cloudevents.core.v03.CloudEventBuilder v03() {
         return new io.cloudevents.core.v03.CloudEventBuilder();
     }
 
+    /**
+     * @param event event to bootstrap the builder
+     * @return a new CloudEvent v0.3 builder filled with content of {@code event}
+     */
     static io.cloudevents.core.v03.CloudEventBuilder v03(CloudEvent event) {
         return new io.cloudevents.core.v03.CloudEventBuilder(event);
     }
 
+    /**
+     * Create a new builder for the specified {@link SpecVersion}
+     *
+     * @param version version to use for the new builder
+     * @return a new builder
+     */
     static CloudEventBuilder fromSpecVersion(@Nonnull SpecVersion version) {
-
-        io.cloudevents.core.v1.CloudEventBuilder v1 = v1().withId("aaaa");
-
         switch (version) {
             case V1:
                 return CloudEventBuilder.v1();

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -26,7 +26,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<SELF, T>, T extends CloudEvent> implements CloudEventBuilder {
+public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<SELF, T>, T extends CloudEvent> implements CloudEventBuilder<SELF> {
 
     // This is a little trick for enabling fluency
     private SELF self;

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -26,10 +26,10 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<SELF, T>, T extends CloudEvent> implements CloudEventBuilder<SELF> {
+public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<SELF, T>, T extends CloudEvent> implements CloudEventBuilder {
 
     // This is a little trick for enabling fluency
-    private SELF self;
+    private final SELF self;
 
     protected byte[] data;
     protected Map<String, Object> extensions;
@@ -54,10 +54,6 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
 
     protected abstract void setAttributes(CloudEvent event);
 
-    protected abstract SELF withDataContentType(String contentType);
-
-    protected abstract SELF withDataSchema(URI dataSchema);
-
     //TODO builder should accept data as Object and use data codecs (that we need to implement)
     // to encode data
 
@@ -66,14 +62,14 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
         return this.self;
     }
 
-    public SELF withData(String contentType, byte[] data) {
-        withDataContentType(contentType);
+    public SELF withData(String dataContentType, byte[] data) {
+        withDataContentType(dataContentType);
         withData(data);
         return this.self;
     }
 
-    public SELF withData(String contentType, URI dataSchema, byte[] data) {
-        withDataContentType(contentType);
+    public SELF withData(String dataContentType, URI dataSchema, byte[] data) {
+        withDataContentType(dataContentType);
         withDataSchema(dataSchema);
         withData(data);
         return this.self;
@@ -127,6 +123,14 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
 
     @Override
     public CloudEvent end() {
-        return build();
+        try {
+            return build();
+        } catch (Exception e) {
+            throw CloudEventVisitException.newOther(e);
+        }
+    }
+
+    protected static IllegalStateException createMissingAttributeException(String attributeName) {
+        return new IllegalStateException("Attribute '" + attributeName + "' cannot be null");
     }
 }

--- a/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
@@ -85,8 +85,8 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
     }
 
     @Override
-    public CloudEventBuilder withDataContentType(String contentType) {
-        this.datacontenttype = contentType;
+    public CloudEventBuilder withDataContentType(String dataContentType) {
+        this.datacontenttype = dataContentType;
         return this;
     }
 
@@ -96,13 +96,23 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
     }
 
     @Override
-    protected CloudEventBuilder withDataSchema(URI dataSchema) {
+    public CloudEventBuilder withDataSchema(URI dataSchema) {
         this.schemaurl = dataSchema;
         return this;
     }
 
     @Override
     public CloudEventV03 build() {
+        if (id == null) {
+            throw createMissingAttributeException("id");
+        }
+        if (source == null) {
+            throw createMissingAttributeException("source");
+        }
+        if (type == null) {
+            throw createMissingAttributeException("type");
+        }
+
         return new CloudEventV03(id, source, type, time, schemaurl, datacontenttype, subject, this.data, this.extensions);
     }
 

--- a/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
@@ -76,14 +76,14 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
         return this;
     }
 
-    public CloudEventBuilder withDataSchema(URI dataschema) {
-        this.dataschema = dataschema;
+    public CloudEventBuilder withDataSchema(URI dataSchema) {
+        this.dataschema = dataSchema;
         return this;
     }
 
     public CloudEventBuilder withDataContentType(
-        String datacontenttype) {
-        this.datacontenttype = datacontenttype;
+        String dataContentType) {
+        this.datacontenttype = dataContentType;
         return this;
     }
 
@@ -100,6 +100,16 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
 
     @Override
     public CloudEvent build() {
+        if (id == null) {
+            throw createMissingAttributeException("id");
+        }
+        if (source == null) {
+            throw createMissingAttributeException("source");
+        }
+        if (type == null) {
+            throw createMissingAttributeException("type");
+        }
+
         return new CloudEventV1(id, source, type, datacontenttype, dataschema, subject, time, this.data, this.extensions);
     }
 

--- a/core/src/test/java/io/cloudevents/core/extensions/DistributedTracingExtensionTest.java
+++ b/core/src/test/java/io/cloudevents/core/extensions/DistributedTracingExtensionTest.java
@@ -20,6 +20,8 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -33,7 +35,12 @@ public class DistributedTracingExtensionTest {
         tracing.setTraceparent("parent");
         tracing.setTracestate("state");
 
-        CloudEvent event = CloudEventBuilder.v1().withExtension(tracing).build();
+        CloudEvent event = CloudEventBuilder
+            .v1()
+            .withId("aaa")
+            .withSource(URI.create("http://localhost"))
+            .withType("example")
+            .withExtension(tracing).build();
 
         assertThat(event.getExtension(DistributedTracingExtension.TRACEPARENT))
             .isEqualTo("parent");
@@ -44,6 +51,9 @@ public class DistributedTracingExtensionTest {
     @Test
     public void parseExtension() {
         CloudEvent event = CloudEventBuilder.v1()
+            .withId("aaa")
+            .withSource(URI.create("http://localhost"))
+            .withType("example")
             .withExtension(DistributedTracingExtension.TRACEPARENT, "parent")
             .withExtension(DistributedTracingExtension.TRACESTATE, "state")
             .build();

--- a/core/src/test/java/io/cloudevents/core/v03/CloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/v03/CloudEventBuilderTest.java
@@ -23,8 +23,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.net.URI;
+
 import static io.cloudevents.core.test.Data.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * @author fabiojose
@@ -68,6 +71,36 @@ public class CloudEventBuilderTest {
         assertThat(expected.getSpecVersion())
             .isEqualTo(SpecVersion.V1);
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testMissingId() {
+        assertThatCode(() -> CloudEventBuilder
+            .v03()
+            .withSource(URI.create("http://localhost"))
+            .withType("aaa")
+            .build()
+        ).hasMessageContaining("Attribute 'id' cannot be null");
+    }
+
+    @Test
+    void testMissingSource() {
+        assertThatCode(() -> CloudEventBuilder
+            .v03()
+            .withId("000")
+            .withType("aaa")
+            .build()
+        ).hasMessageContaining("Attribute 'source' cannot be null");
+    }
+
+    @Test
+    void testMissingType() {
+        assertThatCode(() -> CloudEventBuilder
+            .v03()
+            .withId("000")
+            .withSource(URI.create("http://localhost"))
+            .build()
+        ).hasMessageContaining("Attribute 'type' cannot be null");
     }
 
 }

--- a/core/src/test/java/io/cloudevents/core/v1/CloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/v1/CloudEventBuilderTest.java
@@ -23,8 +23,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.net.URI;
+
 import static io.cloudevents.core.test.Data.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 
 /**
@@ -69,6 +72,36 @@ public class CloudEventBuilderTest {
         assertThat(expected.getSpecVersion())
             .isEqualTo(SpecVersion.V03);
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testMissingId() {
+        assertThatCode(() -> CloudEventBuilder
+            .v1()
+            .withSource(URI.create("http://localhost"))
+            .withType("aaa")
+            .build()
+        ).hasMessageContaining("Attribute 'id' cannot be null");
+    }
+
+    @Test
+    void testMissingSource() {
+        assertThatCode(() -> CloudEventBuilder
+            .v1()
+            .withId("000")
+            .withType("aaa")
+            .build()
+        ).hasMessageContaining("Attribute 'source' cannot be null");
+    }
+
+    @Test
+    void testMissingType() {
+        assertThatCode(() -> CloudEventBuilder
+            .v1()
+            .withId("000")
+            .withSource(URI.create("http://localhost"))
+            .build()
+        ).hasMessageContaining("Attribute 'type' cannot be null");
     }
 
 }


### PR DESCRIPTION
Fix #161

* `CloudEventBuilder` interface now has methods `withId`, `withSource`, ... in a similar fashion to `CloudEventAttributes`.
* `CloudEventBuilder` now fails if the mandatory attributes are not configured
