### PR TITLE
Added json format & kafka benchmarks

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,0 +1,168 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <!--
+      ~ Copyright 2018-Present The CloudEvents Authors
+      ~ <p>
+      ~ Licensed under the Apache License, Version 2.0 (the "License");
+      ~ you may not use this file except in compliance with the License.
+      ~ You may obtain a copy of the License at
+      ~ <p>
+      ~ http://www.apache.org/licenses/LICENSE-2.0
+      ~ <p>
+      ~ Unless required by applicable law or agreed to in writing, software
+      ~ distributed under the License is distributed on an "AS IS" BASIS,
+      ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      ~ See the License for the specific language governing permissions and
+      ~ limitations under the License.
+      ~
+      -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.cloudevents</groupId>
+        <artifactId>cloudevents-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cloudevents-benchmarks</artifactId>
+    <packaging>jar</packaging>
+    <name>CloudEvents - Benchmarks</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.23</jmh.version>
+        <javac.target>1.8</javac.target>
+        <!-- Name of the benchmark Uber-JAR to generate. -->
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-json-jackson</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-kafka</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <compilerVersion>${javac.target}</compilerVersion>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.17</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/benchmarks/src/main/java/io/cloudevents/bench/jackson/JsonFormatDeserializationBenchmark.java
+++ b/benchmarks/src/main/java/io/cloudevents/bench/jackson/JsonFormatDeserializationBenchmark.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.bench.jackson;
+
+import io.cloudevents.jackson.JsonFormat;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static io.cloudevents.core.test.Data.V1_WITH_JSON_DATA_WITH_EXT;
+import static io.cloudevents.core.test.Data.V1_WITH_XML_DATA;
+
+public class JsonFormatDeserializationBenchmark {
+
+    @State(Scope.Thread)
+    public static class DeserializationState {
+
+        public byte[] eventWithJson;
+        public byte[] eventWithXml;
+        public JsonFormat format = new JsonFormat();
+
+        public DeserializationState() {
+            eventWithJson = format.serialize(V1_WITH_JSON_DATA_WITH_EXT);
+            eventWithXml = format.serialize(V1_WITH_XML_DATA);
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void deserializeWithJsonData(DeserializationState state, Blackhole bh) {
+        bh.consume(
+            state.format.deserialize(state.eventWithJson)
+        );
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void deserializeWithXmlData(DeserializationState state, Blackhole bh) {
+        bh.consume(
+            state.format.deserialize(state.eventWithXml)
+        );
+    }
+
+}

--- a/benchmarks/src/main/java/io/cloudevents/bench/jackson/JsonFormatSerializationBenchmark.java
+++ b/benchmarks/src/main/java/io/cloudevents/bench/jackson/JsonFormatSerializationBenchmark.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.bench.jackson;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.jackson.JsonFormat;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static io.cloudevents.core.test.Data.V1_WITH_JSON_DATA_WITH_EXT;
+import static io.cloudevents.core.test.Data.V1_WITH_XML_DATA;
+
+public class JsonFormatSerializationBenchmark {
+
+    @State(Scope.Thread)
+    public static class SerializationState {
+        public CloudEvent eventWithJson = CloudEventBuilder.v1(V1_WITH_JSON_DATA_WITH_EXT).build();
+        public CloudEvent eventWithXml = CloudEventBuilder.v1(V1_WITH_XML_DATA).build();
+        public JsonFormat format = new JsonFormat();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void serializeWithJsonData(SerializationState state, Blackhole bh) {
+        bh.consume(
+            state.format.serialize(state.eventWithJson)
+        );
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void serializeWithXmlData(SerializationState state, Blackhole bh) {
+        bh.consume(
+            state.format.serialize(state.eventWithXml)
+        );
+    }
+
+}

--- a/benchmarks/src/main/java/io/cloudevents/bench/kafka/CloudEventToKafkaProducerMessageBenchmark.java
+++ b/benchmarks/src/main/java/io/cloudevents/bench/kafka/CloudEventToKafkaProducerMessageBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.bench.kafka;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.jackson.JsonFormat;
+import io.cloudevents.kafka.KafkaMessageFactory;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static io.cloudevents.core.test.Data.V1_WITH_JSON_DATA_WITH_EXT;
+
+
+public class CloudEventToKafkaProducerMessageBenchmark {
+
+    @State(Scope.Thread)
+    public static class Event {
+        public CloudEvent event = CloudEventBuilder.v1(V1_WITH_JSON_DATA_WITH_EXT).build();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void testBinaryEncoding(Event event, Blackhole bh) {
+        bh.consume(
+            KafkaMessageFactory
+                .createWriter("aaa")
+                .writeBinary(event.event)
+        );
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void testStructuredJsonEncoding(Event event, Blackhole bh) {
+        bh.consume(
+            KafkaMessageFactory
+                .createWriter("aaa")
+                .writeStructured(event.event, JsonFormat.CONTENT_TYPE)
+        );
+    }
+
+}

--- a/benchmarks/src/main/java/io/cloudevents/bench/kafka/KafkaConsumerMessageToCloudEventBenchmark.java
+++ b/benchmarks/src/main/java/io/cloudevents/bench/kafka/KafkaConsumerMessageToCloudEventBenchmark.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.bench.kafka;
+
+import io.cloudevents.jackson.JsonFormat;
+import io.cloudevents.kafka.KafkaMessageFactory;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static io.cloudevents.core.test.Data.V1_WITH_JSON_DATA_WITH_EXT;
+
+public class KafkaConsumerMessageToCloudEventBenchmark {
+
+    @State(Scope.Thread)
+    public static class BinaryMessage {
+        public ConsumerRecord<String, byte[]> message;
+
+        public BinaryMessage() {
+            // Hack to generate a consumer message
+            ProducerRecord<Void, byte[]> inRecord = KafkaMessageFactory
+                .createWriter("aaa")
+                .writeBinary(V1_WITH_JSON_DATA_WITH_EXT);
+
+            this.message = new ConsumerRecord<>(
+                "aaa",
+                0,
+                0,
+                0,
+                TimestampType.NO_TIMESTAMP_TYPE,
+                -1L,
+                ConsumerRecord.NULL_SIZE,
+                ConsumerRecord.NULL_SIZE,
+                "aaa",
+                inRecord.value(),
+                inRecord.headers()
+            );
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void testBinaryEncoding(BinaryMessage binaryMessage, Blackhole bh) {
+        bh.consume(
+            KafkaMessageFactory
+                .createReader(binaryMessage.message)
+                .toEvent()
+        );
+    }
+
+    @State(Scope.Thread)
+    public static class StructuredJsonMessage {
+        public ConsumerRecord<String, byte[]> message;
+
+        public StructuredJsonMessage() {
+            // Hack to generate a consumer message
+            ProducerRecord<Void, byte[]> inRecord = KafkaMessageFactory
+                .createWriter("aaa")
+                .writeStructured(V1_WITH_JSON_DATA_WITH_EXT, JsonFormat.CONTENT_TYPE);
+
+            this.message = new ConsumerRecord<>(
+                "aaa",
+                0,
+                0,
+                0,
+                TimestampType.NO_TIMESTAMP_TYPE,
+                -1L,
+                ConsumerRecord.NULL_SIZE,
+                ConsumerRecord.NULL_SIZE,
+                "aaa",
+                inRecord.value(),
+                inRecord.headers()
+            );
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void testStructuredJsonEncoding(StructuredJsonMessage structuredJsonMessage, Blackhole bh) {
+        bh.consume(
+            KafkaMessageFactory
+                .createReader(structuredJsonMessage.message)
+                .toEvent()
+        );
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
                 </property>
             </activation>
             <modules>
+                <module>benchmarks</module>
                 <module>http/restful-ws-integration-tests</module>
             </modules>
         </profile>


### PR DESCRIPTION
This PR introduces a new module to host microbenchmarks of the various core features and integrations. I opted for a single module for simplicity and because it may be useful in future to add benchs to cross test performance between one integration and another (eg from vertx to kafka).

The benchmarks added in this PR are about:

* JsonFormat serialization and deserialization
* CloudEvent read/write from/to Kafka

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>