### PR TITLE
Fix Graalvm travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ jobs:
     - name: "GraalVM 20.1.0 (8)"
       if: type != pull_request
       install: . ./install-jdk.sh --url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java8-linux-amd64-20.1.0.tar.gz"
-      script: mvn clean verify -B
+      script: mvn clean install -B
     - name: "GraalVM 20.1.0 (11)"
       if: type != pull_request
       install: . ./install-jdk.sh --url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java11-linux-amd64-20.1.0.tar.gz"
-      script: mvn clean verify -B
+      script: mvn clean install -B
     - stage: deploy
       if: type != pull_request
       name: Deploy to Maven Repository


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

The Quarkus tests will require the other cloudevents libraries to be in the local maven repository, that's why the goal has been changed from `verify` to `install`