### PR TITLE
Add CloudEventsProvider to services

### DIFF
--- a/examples/restful-ws-quarkus/src/main/resources/application.properties
+++ b/examples/restful-ws-quarkus/src/main/resources/application.properties
@@ -4,6 +4,3 @@
 ## The Rest client will send events to the local UserResource
 io.cloudevents.examples.quarkus.client.UserClient/mp-rest/url=http://localhost:8080
 io.cloudevents.examples.quarkus.client.UserClient/mp-rest/scope=javax.inject.Singleton
-
-quarkus.index-dependency.cloudevents.group-id=io.cloudevents
-quarkus.index-dependency.cloudevents.artifact-id=cloudevents-http-restful-ws

--- a/http/restful-ws/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/http/restful-ws/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,0 +1,1 @@
+io.cloudevents.http.restful.ws.CloudEventsProvider


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

With these changes, the CloudEventsProvider will be picked up automatically by any library depending on the java-sdk. Look at the changes removed from the restful-ws-quarkus example.