### PR TITLE
Add ARM64 support for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,12 @@ jobs:
     - name: "OpenJDK 11"
       jdk: openjdk11
       script: mvn clean verify -B
-    # GraalVM
+    - if: branches == master
+      name: "OpenJDK 11"
+      arch: arm64
+      jdk: openjdk11
+      script: ./mvnw clean verify -B
+   # GraalVM
     - name: "GraalVM 20.1.0 (8)"
       if: type != pull_request
       install: . ./install-jdk.sh --url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java8-linux-amd64-20.1.0.tar.gz"
@@ -34,6 +39,11 @@ jobs:
       if: type != pull_request
       install: . ./install-jdk.sh --url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java11-linux-amd64-20.1.0.tar.gz"
       script: mvn clean install -B
+    - name: "GraalVM 20.2.0 (11)"
+      arch: arm64
+      if: type != pull_request
+      install: . ./install-jdk.sh --url "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java11-linux-aarch64-20.2.0.tar.gz"
+      script: ./mvnw clean install -B
     - stage: deploy
       if: type != pull_request
       name: Deploy to Maven Repository


### PR DESCRIPTION
Added ARM64 job in Travis-CI for openjdk8, openjdk11 and graalvm openjdk11.

Signed-off-by: odidev <odidev@puresoftware.com>