### PR TITLE
Serialize time to RFC3339 compliant string

### DIFF
--- a/api/src/main/java/io/cloudevents/types/Time.java
+++ b/api/src/main/java/io/cloudevents/types/Time.java
@@ -20,6 +20,8 @@ package io.cloudevents.types;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
 /**
  * Utilities to handle the <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system">CloudEvent Attribute Timestamp type</a>
  */
@@ -36,9 +38,9 @@ public final class Time {
     }
 
     /**
-     * Convert a {@link OffsetDateTime} to {@link String}
+     * Convert a {@link OffsetDateTime} to a RFC3339 compliant {@link String}
      */
     public static String writeTime(OffsetDateTime time) throws DateTimeParseException {
-        return time.toString();
+        return ISO_OFFSET_DATE_TIME.format(time);
     }
 }

--- a/api/src/test/java/io/cloudevents/types/TimeTest.java
+++ b/api/src/test/java/io/cloudevents/types/TimeTest.java
@@ -49,7 +49,7 @@ public class TimeTest {
         assertThat(Time.writeTime(OffsetDateTime.of(
             LocalDateTime.of(2020, 8, 3, 18, 10, 0, 0),
             ZoneOffset.ofHours(2)
-        ))).isEqualTo("2020-08-03T18:10+02:00");
+        ))).isEqualTo("2020-08-03T18:10:00+02:00");
     }
 
     public static Stream<Arguments> parseDateArguments() {

--- a/formats/json-jackson/src/test/resources/v1/json_data_with_fractional_time.json
+++ b/formats/json-jackson/src/test/resources/v1/json_data_with_fractional_time.json
@@ -7,5 +7,5 @@
     "datacontenttype": "application/json",
     "data": {},
     "subject": "sub",
-    "time": "2018-04-26T14:48:09.123400Z"
+    "time": "2018-04-26T14:48:09.1234Z"
 }


### PR DESCRIPTION
According to the [documentation](https://docs.oracle.com/javase/8/docs/api/java/time/OffsetDateTime.html#toString--), `OffsetDateTime`'s `toString` method uses this format `uuuu-MM-dd'T'HH:mmXXXXX` when seconds is zero. This is incompatible with RFC3339 and cannot be parsed by other cloud events SDKs. 

Here is an demo of the incompatibility:
https://play.golang.org/p/9db3zuJTM_k 