### PR TITLE
Introduce CloudEventData

### DIFF
--- a/api/src/main/java/io/cloudevents/CloudEvent.java
+++ b/api/src/main/java/io/cloudevents/CloudEvent.java
@@ -28,5 +28,5 @@ public interface CloudEvent extends CloudEventAttributes, CloudEventExtensions {
      * The event data
      */
     @Nullable
-    byte[] getData();
+    CloudEventData getData();
 }

--- a/api/src/main/java/io/cloudevents/CloudEventData.java
+++ b/api/src/main/java/io/cloudevents/CloudEventData.java
@@ -1,11 +1,7 @@
 package io.cloudevents;
 
-import java.util.function.Function;
-
 /**
- * Interface that defines a container for CloudEvent data.
- *
- * Every CloudEvent data has
+ * Interface that defines a wrapper for CloudEvent data.
  */
 public interface CloudEventData {
 

--- a/api/src/main/java/io/cloudevents/CloudEventData.java
+++ b/api/src/main/java/io/cloudevents/CloudEventData.java
@@ -2,10 +2,19 @@ package io.cloudevents;
 
 import java.util.function.Function;
 
+/**
+ * Interface that defines a container for CloudEvent data.
+ *
+ * Every CloudEvent data has
+ */
 public interface CloudEventData {
 
+    /**
+     * @return this CloudEventData, represented as bytes. Note: this operation may be expensive, depending on the internal representation of data
+     */
     byte[] toBytes();
 
+    //TBD
     <T> T to(Function<Object, T> mapper);
 
 }

--- a/api/src/main/java/io/cloudevents/CloudEventData.java
+++ b/api/src/main/java/io/cloudevents/CloudEventData.java
@@ -1,0 +1,11 @@
+package io.cloudevents;
+
+import java.util.function.Function;
+
+public interface CloudEventData {
+
+    byte[] toBytes();
+
+    <T> T to(Function<Object, T> mapper);
+
+}

--- a/api/src/main/java/io/cloudevents/CloudEventData.java
+++ b/api/src/main/java/io/cloudevents/CloudEventData.java
@@ -14,7 +14,4 @@ public interface CloudEventData {
      */
     byte[] toBytes();
 
-    //TBD
-    <T> T to(Function<Object, T> mapper);
-
 }

--- a/api/src/main/java/io/cloudevents/rw/CloudEventWriter.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventWriter.java
@@ -17,6 +17,8 @@
 
 package io.cloudevents.rw;
 
+import io.cloudevents.CloudEventData;
+
 /**
  * Interface to write the content (CloudEvents attributes, extensions and payload) from a
  * {@link io.cloudevents.rw.CloudEventReader} to a new representation.
@@ -30,7 +32,7 @@ public interface CloudEventWriter<R> extends CloudEventAttributesWriter, CloudEv
      *
      * @return an eventual return value
      */
-    R end(byte[] value) throws CloudEventRWException;
+    R end(CloudEventData data) throws CloudEventRWException;
 
     /**
      * End the visit

--- a/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
@@ -18,6 +18,7 @@
 package io.cloudevents.core.builder;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
 import io.cloudevents.Extension;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.rw.CloudEventWriter;
@@ -95,7 +96,7 @@ public interface CloudEventBuilder extends CloudEventWriter<CloudEvent> {
      * @param data data of the event
      * @return self
      */
-    CloudEventBuilder withData(byte[] data);
+    CloudEventBuilder withData(CloudEventData data);
 
     /**
      * Set the {@code datacontenttype} and {@code data} of the event
@@ -104,7 +105,7 @@ public interface CloudEventBuilder extends CloudEventWriter<CloudEvent> {
      * @param data            data of the event
      * @return self
      */
-    CloudEventBuilder withData(String dataContentType, byte[] data);
+    CloudEventBuilder withData(String dataContentType, CloudEventData data);
 
     /**
      * Set the {@code datacontenttype}, {@code dataschema} and {@code data} of the event
@@ -114,7 +115,7 @@ public interface CloudEventBuilder extends CloudEventWriter<CloudEvent> {
      * @param data            data of the event
      * @return self
      */
-    CloudEventBuilder withData(String dataContentType, URI dataSchema, byte[] data);
+    CloudEventBuilder withData(String dataContentType, URI dataSchema, CloudEventData data);
 
     /**
      * Set an extension with provided key and string value

--- a/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
@@ -96,6 +96,33 @@ public interface CloudEventBuilder extends CloudEventWriter<CloudEvent> {
      * @param data data of the event
      * @return self
      */
+    CloudEventBuilder withData(byte[] data);
+
+    /**
+     * Set the {@code datacontenttype} and {@code data} of the event
+     *
+     * @param dataContentType datacontenttype of the event
+     * @param data            data of the event
+     * @return self
+     */
+    CloudEventBuilder withData(String dataContentType, byte[] data);
+
+    /**
+     * Set the {@code datacontenttype}, {@code dataschema} and {@code data} of the event
+     *
+     * @param dataContentType datacontenttype of the event
+     * @param dataSchema      dataschema of the event
+     * @param data            data of the event
+     * @return self
+     */
+    CloudEventBuilder withData(String dataContentType, URI dataSchema, byte[] data);
+
+    /**
+     * Set the {@code data} of the event
+     *
+     * @param data data of the event
+     * @return self
+     */
     CloudEventBuilder withData(CloudEventData data);
 
     /**

--- a/core/src/main/java/io/cloudevents/core/data/BytesCloudEventData.java
+++ b/core/src/main/java/io/cloudevents/core/data/BytesCloudEventData.java
@@ -1,0 +1,41 @@
+package io.cloudevents.core.data;
+
+import io.cloudevents.CloudEventData;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class BytesCloudEventData implements CloudEventData {
+
+    private final byte[] value;
+
+    public BytesCloudEventData(byte[] value) {
+        Objects.requireNonNull(value);
+        this.value = value;
+    }
+
+    @Override
+    public byte[] toBytes() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BytesCloudEventData that = (BytesCloudEventData) o;
+        return Arrays.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "BytesCloudEventData{" +
+            "value=" + Arrays.toString(value) +
+            '}';
+    }
+}

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEvent.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEvent.java
@@ -18,6 +18,7 @@
 package io.cloudevents.core.impl;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
 import io.cloudevents.rw.*;
 
 import java.util.HashMap;
@@ -26,16 +27,16 @@ import java.util.Set;
 
 public abstract class BaseCloudEvent implements CloudEvent, CloudEventReader {
 
-    private final byte[] data;
+    private final CloudEventData data;
     protected final Map<String, Object> extensions;
 
-    protected BaseCloudEvent(byte[] data, Map<String, Object> extensions) {
+    protected BaseCloudEvent(CloudEventData data, Map<String, Object> extensions) {
         this.data = data;
         this.extensions = extensions != null ? extensions : new HashMap<>();
     }
 
     @Override
-    public byte[] getData() {
+    public CloudEventData getData() {
         return this.data;
     }
 

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -18,8 +18,10 @@
 package io.cloudevents.core.impl;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
 import io.cloudevents.Extension;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.rw.CloudEventRWException;
 
 import javax.annotation.Nonnull;
@@ -32,7 +34,7 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     // This is a little trick for enabling fluency
     private final SELF self;
 
-    protected byte[] data;
+    protected CloudEventData data;
     protected Map<String, Object> extensions;
 
     @SuppressWarnings("unchecked")
@@ -59,7 +61,7 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     // to encode data
 
     public SELF withData(byte[] data) {
-        this.data = data;
+        this.data = new BytesCloudEventData(data);
         return this.self;
     }
 
@@ -70,6 +72,24 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     }
 
     public SELF withData(String dataContentType, URI dataSchema, byte[] data) {
+        withDataContentType(dataContentType);
+        withDataSchema(dataSchema);
+        withData(data);
+        return this.self;
+    }
+
+    public SELF withData(CloudEventData data) {
+        this.data = data;
+        return this.self;
+    }
+
+    public SELF withData(String dataContentType, CloudEventData data) {
+        withDataContentType(dataContentType);
+        withData(data);
+        return this.self;
+    }
+
+    public SELF withData(String dataContentType, URI dataSchema, CloudEventData data) {
         withDataContentType(dataContentType);
         withDataSchema(dataSchema);
         withData(data);
@@ -114,7 +134,7 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     }
 
     @Override
-    public CloudEvent end(byte[] value) throws CloudEventRWException {
+    public CloudEvent end(CloudEventData value) throws CloudEventRWException {
         this.data = value;
         return build();
     }

--- a/core/src/main/java/io/cloudevents/core/message/impl/BaseGenericBinaryMessageReaderImpl.java
+++ b/core/src/main/java/io/cloudevents/core/message/impl/BaseGenericBinaryMessageReaderImpl.java
@@ -17,6 +17,7 @@
 
 package io.cloudevents.core.message.impl;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.rw.*;
 
@@ -34,9 +35,9 @@ import java.util.function.BiConsumer;
 public abstract class BaseGenericBinaryMessageReaderImpl<HK, HV> extends BaseBinaryMessageReader {
 
     private final SpecVersion version;
-    private final byte[] body;
+    private final CloudEventData body;
 
-    protected BaseGenericBinaryMessageReaderImpl(SpecVersion version, byte[] body) {
+    protected BaseGenericBinaryMessageReaderImpl(SpecVersion version, CloudEventData body) {
         Objects.requireNonNull(version);
         this.version = version;
         this.body = body;
@@ -66,7 +67,7 @@ public abstract class BaseGenericBinaryMessageReaderImpl<HK, HV> extends BaseBin
         });
 
         // Set the payload
-        if (this.body != null && this.body.length != 0) {
+        if (this.body != null) {
             return visitor.end(this.body);
         }
 

--- a/core/src/main/java/io/cloudevents/core/v03/CloudEventV03.java
+++ b/core/src/main/java/io/cloudevents/core/v03/CloudEventV03.java
@@ -16,6 +16,7 @@
  */
 package io.cloudevents.core.v03;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.impl.BaseCloudEvent;
 import io.cloudevents.lang.Nullable;
@@ -24,7 +25,6 @@ import io.cloudevents.rw.CloudEventRWException;
 
 import java.net.URI;
 import java.time.OffsetDateTime;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
@@ -47,7 +47,7 @@ public final class CloudEventV03 extends BaseCloudEvent {
     public CloudEventV03(String id, URI source, String type,
                          OffsetDateTime time, URI schemaurl,
                          String datacontenttype, String subject,
-                         byte[] data, Map<String, Object> extensions) {
+                         CloudEventData data, Map<String, Object> extensions) {
         super(data, extensions);
 
         this.id = id;
@@ -172,13 +172,13 @@ public final class CloudEventV03 extends BaseCloudEvent {
             Objects.equals(schemaurl, that.schemaurl) &&
             Objects.equals(getSubject(), that.getSubject()) &&
             Objects.equals(getTime(), that.getTime()) &&
-            Arrays.equals(getData(), that.getData()) &&
+            Objects.equals(getData(), that.getData()) &&
             Objects.equals(this.extensions, that.extensions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getSource(), getType(), datacontenttype, schemaurl, getSubject(), getTime(), Arrays.hashCode(getData()), this.extensions);
+        return Objects.hash(getId(), getSource(), getType(), datacontenttype, schemaurl, getSubject(), getTime(), getData(), this.extensions);
     }
 
     @Override
@@ -191,7 +191,7 @@ public final class CloudEventV03 extends BaseCloudEvent {
             ", schemaurl=" + schemaurl +
             ", subject='" + subject + '\'' +
             ", time=" + time +
-            ", data=" + Arrays.toString(getData()) +
+            ", data=" + getData() +
             ", extensions" + this.extensions +
             '}';
     }

--- a/core/src/main/java/io/cloudevents/core/v1/CloudEventV1.java
+++ b/core/src/main/java/io/cloudevents/core/v1/CloudEventV1.java
@@ -16,6 +16,7 @@
  */
 package io.cloudevents.core.v1;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.impl.BaseCloudEvent;
 import io.cloudevents.rw.CloudEventAttributesWriter;
@@ -23,7 +24,6 @@ import io.cloudevents.rw.CloudEventRWException;
 
 import java.net.URI;
 import java.time.OffsetDateTime;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
@@ -46,7 +46,7 @@ public final class CloudEventV1 extends BaseCloudEvent {
     public CloudEventV1(String id, URI source,
                         String type, String datacontenttype,
                         URI dataschema, String subject, OffsetDateTime time,
-                        byte[] data, Map<String, Object> extensions) {
+                        CloudEventData data, Map<String, Object> extensions) {
         super(data, extensions);
 
         this.id = id;
@@ -167,13 +167,13 @@ public final class CloudEventV1 extends BaseCloudEvent {
             Objects.equals(dataschema, that.getDataSchema()) &&
             Objects.equals(getSubject(), that.getSubject()) &&
             Objects.equals(getTime(), that.getTime()) &&
-            Arrays.equals(getData(), that.getData()) &&
+            Objects.equals(getData(), that.getData()) &&
             Objects.equals(this.extensions, that.extensions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getSource(), getType(), datacontenttype, dataschema, getSubject(), getTime(), Arrays.hashCode(getData()), this.extensions);
+        return Objects.hash(getId(), getSource(), getType(), datacontenttype, dataschema, getSubject(), getTime(), getData(), this.extensions);
     }
 
     @Override
@@ -186,7 +186,7 @@ public final class CloudEventV1 extends BaseCloudEvent {
             ", dataschema=" + dataschema +
             ", subject='" + subject + '\'' +
             ", time=" + time +
-            ", data=" + Arrays.toString(getData()) +
+            ", data=" + getData() +
             ", extensions=" + this.extensions +
             '}';
     }

--- a/core/src/test/java/io/cloudevents/core/mock/CSVFormat.java
+++ b/core/src/test/java/io/cloudevents/core/mock/CSVFormat.java
@@ -51,7 +51,7 @@ public class CSVFormat implements EventFormat {
                 ? Time.writeTime(event.getTime())
                 : "null",
             event.getData() != null
-                ? new String(Base64.getEncoder().encode(event.getData()), StandardCharsets.UTF_8)
+                ? new String(Base64.getEncoder().encode(event.getData().toBytes()), StandardCharsets.UTF_8)
                 : "null"
         ).getBytes();
     }

--- a/core/src/test/java/io/cloudevents/core/mock/MockBinaryMessageWriter.java
+++ b/core/src/test/java/io/cloudevents/core/mock/MockBinaryMessageWriter.java
@@ -18,7 +18,9 @@
 package io.cloudevents.core.mock;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.core.impl.CloudEventUtils;
 import io.cloudevents.core.message.MessageReader;
 import io.cloudevents.core.message.impl.BaseBinaryMessageReader;
@@ -33,14 +35,18 @@ public class MockBinaryMessageWriter extends BaseBinaryMessageReader implements 
 
     private SpecVersion version;
     private Map<String, Object> attributes;
-    private byte[] data;
+    private CloudEventData data;
     private Map<String, Object> extensions;
 
-    public MockBinaryMessageWriter(SpecVersion version, Map<String, Object> attributes, byte[] data, Map<String, Object> extensions) {
+    public MockBinaryMessageWriter(SpecVersion version, Map<String, Object> attributes, CloudEventData data, Map<String, Object> extensions) {
         this.version = version;
         this.attributes = attributes;
         this.data = data;
         this.extensions = extensions;
+    }
+
+    public MockBinaryMessageWriter(SpecVersion version, Map<String, Object> attributes, byte[] data, Map<String, Object> extensions) {
+        this(version, attributes, new BytesCloudEventData(data), extensions);
     }
 
     public MockBinaryMessageWriter() {
@@ -65,7 +71,7 @@ public class MockBinaryMessageWriter extends BaseBinaryMessageReader implements 
         this.readAttributes(visitor);
         this.readExtensions(visitor);
 
-        if (this.data != null && this.data.length != 0) {
+        if (this.data != null) {
             return visitor.end(this.data);
         }
 
@@ -105,7 +111,7 @@ public class MockBinaryMessageWriter extends BaseBinaryMessageReader implements 
     }
 
     @Override
-    public MockBinaryMessageWriter end(byte[] value) throws CloudEventRWException {
+    public MockBinaryMessageWriter end(CloudEventData value) throws CloudEventRWException {
         this.data = value;
         return this;
     }

--- a/examples/basic-http/src/main/java/io/cloudevents/examples/http/basic/HttpURLConnectionClient.java
+++ b/examples/basic-http/src/main/java/io/cloudevents/examples/http/basic/HttpURLConnectionClient.java
@@ -57,7 +57,9 @@ public class HttpURLConnectionClient {
         CloudEvent receivedCE = messageReader.toEvent();
 
         System.out.println("CloudEvent: " + receivedCE);
-        System.out.println("Data: " + new String(receivedCE.getData(), StandardCharsets.UTF_8));
+        if (receivedCE.getData() != null) {
+            System.out.println("Data: " + new String(receivedCE.getData().toBytes(), StandardCharsets.UTF_8));
+        }
     }
 
     private static MessageReader createMessageReader(HttpURLConnection httpUrlConnection) throws IOException {

--- a/examples/restful-ws-quarkus/src/main/java/io/cloudevents/examples/quarkus/resources/UserResource.java
+++ b/examples/restful-ws-quarkus/src/main/java/io/cloudevents/examples/quarkus/resources/UserResource.java
@@ -1,26 +1,19 @@
 package io.cloudevents.examples.quarkus.resources;
 
-import java.util.HashMap;
-import java.util.Map;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
-
 import io.cloudevents.CloudEvent;
 import io.cloudevents.examples.quarkus.model.User;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.HashMap;
+import java.util.Map;
 
 @Path("/users")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -53,7 +46,7 @@ public class UserResource {
         if (event == null || event.getData() == null) {
             throw new BadRequestException("Invalid data received. Null or empty event");
         }
-        User user = Json.decodeValue(Buffer.buffer(event.getData()), User.class);
+        User user = Json.decodeValue(Buffer.buffer(event.getData().toBytes()), User.class);
         if (users.containsKey(user.getUsername())) {
             throw new BadRequestException("Username already exists: " + user.getUsername());
         }

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.rw.*;
 
 import java.io.IOException;
@@ -142,7 +143,7 @@ public class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
                 });
 
                 if (data != null) {
-                    return visitor.end(data);
+                    return visitor.end(new BytesCloudEventData(data));
                 }
                 return visitor.end();
             } catch (IOException e) {

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
@@ -112,9 +112,9 @@ public class CloudEventSerializer extends StdSerializer<CloudEvent> {
         }
 
         // Serialize data
-        byte[] data = value.getData();
-        String contentType = value.getDataContentType();
-        if (data != null) {
+        if (value.getData() != null) {
+            byte[] data = value.getData().toBytes();
+            String contentType = value.getDataContentType();
             if (shouldSerializeBase64(contentType)) {
                 switch (value.getSpecVersion()) {
                     case V03:

--- a/http/basic/src/main/java/io/cloudevents/http/impl/HttpMessageReader.java
+++ b/http/basic/src/main/java/io/cloudevents/http/impl/HttpMessageReader.java
@@ -16,7 +16,9 @@
 
 package io.cloudevents.http.impl;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
 
 import java.util.function.BiConsumer;
@@ -27,11 +29,15 @@ import static io.cloudevents.http.impl.CloudEventsHeaders.CONTENT_TYPE;
 
 public class HttpMessageReader extends BaseGenericBinaryMessageReaderImpl<String, String> {
 
-    private final Consumer<BiConsumer<String,String>> forEachHeader;
+    private final Consumer<BiConsumer<String, String>> forEachHeader;
 
-    public HttpMessageReader(SpecVersion version, Consumer<BiConsumer<String,String>> forEachHeader, byte[] body) {
+    public HttpMessageReader(SpecVersion version, Consumer<BiConsumer<String, String>> forEachHeader, CloudEventData body) {
         super(version, body);
         this.forEachHeader = forEachHeader;
+    }
+
+    public HttpMessageReader(SpecVersion version, Consumer<BiConsumer<String, String>> forEachHeader, byte[] body) {
+        this(version, forEachHeader, body != null && body.length > 0 ? new BytesCloudEventData(body) : null);
     }
 
     @Override

--- a/http/basic/src/main/java/io/cloudevents/http/impl/HttpMessageWriter.java
+++ b/http/basic/src/main/java/io/cloudevents/http/impl/HttpMessageWriter.java
@@ -16,6 +16,7 @@
 
 package io.cloudevents.http.impl;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.message.MessageWriter;
@@ -45,8 +46,8 @@ public class HttpMessageWriter implements CloudEventWriter<Void>, MessageWriter<
     }
 
     @Override
-    public Void end(byte[] value) throws CloudEventRWException {
-        putBody.accept(value);
+    public Void end(CloudEventData value) throws CloudEventRWException {
+        putBody.accept(value.toBytes());
         return null;
     }
 

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
@@ -18,6 +18,7 @@
 package io.cloudevents.http.restful.ws.impl;
 
 import io.cloudevents.SpecVersion;
+import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -32,7 +33,7 @@ public final class BinaryRestfulWSMessageReaderImpl extends BaseGenericBinaryMes
     private final MultivaluedMap<String, String> headers;
 
     public BinaryRestfulWSMessageReaderImpl(SpecVersion version, MultivaluedMap<String, String> headers, byte[] body) {
-        super(version, body);
+        super(version, body != null && body.length > 0 ? new BytesCloudEventData(body) : null);
 
         Objects.requireNonNull(headers);
         this.headers = headers;

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSClientMessageWriter.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSClientMessageWriter.java
@@ -17,6 +17,7 @@
 
 package io.cloudevents.http.restful.ws.impl;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.message.MessageWriter;
@@ -58,8 +59,8 @@ public final class RestfulWSClientMessageWriter implements CloudEventWriter<Void
     }
 
     @Override
-    public Void end(byte[] value) throws CloudEventRWException {
-        this.context.setEntity(value);
+    public Void end(CloudEventData value) throws CloudEventRWException {
+        this.context.setEntity(value.toBytes());
         return null;
     }
 

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageWriter.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageWriter.java
@@ -17,6 +17,7 @@
 
 package io.cloudevents.http.restful.ws.impl;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.message.MessageWriter;
@@ -60,9 +61,9 @@ public final class RestfulWSMessageWriter implements CloudEventWriter<Void>, Mes
     }
 
     @Override
-    public Void end(byte[] value) throws CloudEventRWException {
+    public Void end(CloudEventData value) throws CloudEventRWException {
         try {
-            this.entityStream.write(value);
+            this.entityStream.write(value.toBytes());
         } catch (IOException e) {
             throw CloudEventRWException.newOther(e);
         }
@@ -82,7 +83,11 @@ public final class RestfulWSMessageWriter implements CloudEventWriter<Void>, Mes
     @Override
     public Void setEvent(EventFormat format, byte[] value) throws CloudEventRWException {
         this.httpHeaders.add(HttpHeaders.CONTENT_TYPE, format.serializedContentType());
-        this.end(value);
-        return null;
+        try {
+            this.entityStream.write(value);
+        } catch (IOException e) {
+            throw CloudEventRWException.newOther(e);
+        }
+        return this.end();
     }
 }

--- a/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/BinaryVertxMessageReaderImpl.java
+++ b/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/BinaryVertxMessageReaderImpl.java
@@ -18,6 +18,7 @@
 package io.cloudevents.http.vertx.impl;
 
 import io.cloudevents.SpecVersion;
+import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
@@ -31,7 +32,7 @@ public class BinaryVertxMessageReaderImpl extends BaseGenericBinaryMessageReader
     private final MultiMap headers;
 
     public BinaryVertxMessageReaderImpl(SpecVersion version, MultiMap headers, Buffer body) {
-        super(version, (body != null) ? body.getBytes() : null);
+        super(version, body != null && body.length() > 0 ? new BytesCloudEventData(body.getBytes()) : null);
 
         Objects.requireNonNull(headers);
         this.headers = headers;

--- a/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/VertxHttpServerResponseMessageWriterImpl.java
+++ b/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/VertxHttpServerResponseMessageWriterImpl.java
@@ -17,6 +17,7 @@
 
 package io.cloudevents.http.vertx.impl;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.message.MessageWriter;
@@ -57,11 +58,11 @@ public class VertxHttpServerResponseMessageWriterImpl implements MessageWriter<C
     }
 
     @Override
-    public HttpServerResponse end(byte[] value) throws CloudEventRWException {
+    public HttpServerResponse end(CloudEventData value) throws CloudEventRWException {
         if (this.response.ended()) {
             throw CloudEventRWException.newOther(new IllegalStateException("Cannot set the body because the response is already ended"));
         }
-        this.response.end(Buffer.buffer(value));
+        this.response.end(Buffer.buffer(value.toBytes()));
         return this.response;
     }
 

--- a/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/VertxWebClientRequestMessageWriterImpl.java
+++ b/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/VertxWebClientRequestMessageWriterImpl.java
@@ -17,6 +17,7 @@
 
 package io.cloudevents.http.vertx.impl;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.message.MessageWriter;
@@ -59,8 +60,8 @@ public class VertxWebClientRequestMessageWriterImpl implements MessageWriter<Clo
     }
 
     @Override
-    public Future<HttpResponse<Buffer>> end(byte[] value) throws CloudEventRWException {
-        return this.request.sendBuffer(Buffer.buffer(value));
+    public Future<HttpResponse<Buffer>> end(CloudEventData value) throws CloudEventRWException {
+        return this.request.sendBuffer(Buffer.buffer(value.toBytes()));
     }
 
     @Override

--- a/kafka/src/main/java/io/cloudevents/kafka/impl/BaseKafkaMessageWriterImpl.java
+++ b/kafka/src/main/java/io/cloudevents/kafka/impl/BaseKafkaMessageWriterImpl.java
@@ -17,6 +17,7 @@
 
 package io.cloudevents.kafka.impl;
 
+import io.cloudevents.CloudEventData;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.message.MessageWriter;
 import io.cloudevents.rw.CloudEventRWException;
@@ -26,8 +27,8 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 
 abstract class BaseKafkaMessageWriterImpl<R> implements MessageWriter<CloudEventWriter<R>, R>, CloudEventWriter<R> {
 
-    byte[] value;
     final Headers headers;
+    byte[] value;
 
     public BaseKafkaMessageWriterImpl(Headers headers) {
         this.headers = headers;
@@ -46,14 +47,15 @@ abstract class BaseKafkaMessageWriterImpl<R> implements MessageWriter<CloudEvent
     }
 
     @Override
-    public R end(byte[] value) throws CloudEventRWException {
-        this.value = value;
+    public R end(CloudEventData value) throws CloudEventRWException {
+        this.value = value.toBytes();
         return this.end();
     }
 
     @Override
     public R setEvent(EventFormat format, byte[] value) throws CloudEventRWException {
         this.headers.add(new RecordHeader(KafkaHeaders.CONTENT_TYPE, format.serializedContentType().getBytes()));
-        return this.end(value);
+        this.value = value;
+        return this.end();
     }
 }

--- a/kafka/src/main/java/io/cloudevents/kafka/impl/KafkaBinaryMessageReaderImpl.java
+++ b/kafka/src/main/java/io/cloudevents/kafka/impl/KafkaBinaryMessageReaderImpl.java
@@ -18,6 +18,7 @@
 package io.cloudevents.kafka.impl;
 
 import io.cloudevents.SpecVersion;
+import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
 import org.apache.kafka.common.header.Headers;
 
@@ -30,7 +31,7 @@ public class KafkaBinaryMessageReaderImpl extends BaseGenericBinaryMessageReader
     private final Headers headers;
 
     public KafkaBinaryMessageReaderImpl(SpecVersion version, Headers headers, byte[] payload) {
-        super(version, payload);
+        super(version, payload != null && payload.length > 0 ? new BytesCloudEventData(payload) : null);
 
         Objects.requireNonNull(headers);
         this.headers = headers;


### PR DESCRIPTION
## Introduction

I thought a little bit about the problem with the data representation. To do a little recap, we have open these issues/PRs with various discussions about this topic:

* https://github.com/cloudevents/sdk-java/issues/196
* https://github.com/cloudevents/sdk-java/issues/238
* https://github.com/cloudevents/sdk-java/pull/198
* https://github.com/cloudevents/sdk-java/pull/208
* https://github.com/cloudevents/sdk-java/pull/211

I tried to put together all the different discussions we had, the different feedbacks and prepare a proposal to solve the issue, hopefully once and for all :smile: 

## What we're trying to solve

These are the problems we're trying to tackle:

* Users wants to read/write pojos in their CloudEvents, making the experience as nice as possible
* We want to enforce serialization/deserialization to bytes, but we don't want to couple to specific serde libraries
* We want an extensible representation
* We want to avoid double encoding/decoding while serializing/deserializing to any event format (look the #196 for an example outside the sdk), without coupling to a specific json library types

All these problems goes down to a problem: today data can be represented, by our interfaces, only with a byte array.

## How other sdks fix this issue

Before going deep into this proposal, I analyzed a bit what the other SDKs do:

* C# just serves `data` as `object` (the java `Object`). No particular handling is done about it
* Golang represents everything as byte array, so it suffers of the same issues we have
* Rust has a union type defined as string, bytes or json value that represents data. This is possible because in Rust there is one standard de-facto library to interact with json.

## How this new interface works

So this proposal is pretty simple: we add a layer of indirection between data and bytes with a new interface called `CloudEventData`. In particular:

* `getData()` now returns an implementation of `CloudEventData` (if any data). Whatever implementation is, it must be able to convert to bytes
* `CloudEventData` has a single method, `toBytes()`, that identify that going from `data` to bytes is a potentially expensive operation (because it may trigger a conversion from the internal type to bytes).
* 3rd party integrators can implement `CloudEventData` adding whatever they want: marshaller/unmarshaller to pojos, a specific type representing the integration with their own data type, ...

Then the change to `data` is ported to writer, making doable the optimizations to event format/protocol bindings. 

With this new interface, in order to support POJOs, in **core** we need to (in a followup, not this pr):

* Provide a subinterface like `POJOCloudEventData`
* Provide a concrete implementation of `POJOCloudEventData` (it may be `BaseCloudEvent` itself)
* `EventDataCodec` interface to marshal a pojo to bytes

This change doesn't modify the existing assumptions, nor relaxing or enforcing them. It just makes the existing interface more extensible.

What I think it's still a problem in this interface is that we force users to downcast often to retrieve the non bytes internal representation.

Note: This PR is incomplete, I would love to gather feedback first and then move forward with all the changes required to make it working.

cc @johanhaleby @aliok @pierDipi @bsideup 

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>