### PR TITLE
Introduce JsonCloudEventData

### DIFF
--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
@@ -1,0 +1,47 @@
+package io.cloudevents.jackson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.cloudevents.CloudEventData;
+
+import java.util.Objects;
+
+/**
+ * This class is a wrapper for Jackson {@link JsonNode} implementing the {@link CloudEventData}
+ */
+public class JsonCloudEventData implements CloudEventData {
+
+    private final JsonNode node;
+
+    public JsonCloudEventData(JsonNode node) {
+        this.node = node;
+    }
+
+    @Override
+    public byte[] toBytes() {
+        return node.toString().getBytes();
+    }
+
+    public JsonNode getNode() {
+        return node;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JsonCloudEventData that = (JsonCloudEventData) o;
+        return Objects.equals(getNode(), that.getNode());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getNode());
+    }
+
+    @Override
+    public String toString() {
+        return "JsonCloudEventData{" +
+            "node=" + node +
+            '}';
+    }
+}

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
@@ -13,6 +13,7 @@ public class JsonCloudEventData implements CloudEventData {
     private final JsonNode node;
 
     public JsonCloudEventData(JsonNode node) {
+        Objects.requireNonNull(node);
         this.node = node;
     }
 


### PR DESCRIPTION
Followup of #250

This implements an optimization in the jackson CloudEvent ser/de that allows users to directly provide a `JsonNode` as `CloudEvent` data, avoiding the double serialization/deserialization problem.

This is inspired by the discussions here: https://github.com/cloudevents/sdk-java/issues/196

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>