### PR TITLE
CloudEventDataMapper

### DIFF
--- a/api/src/main/java/io/cloudevents/CloudEventData.java
+++ b/api/src/main/java/io/cloudevents/CloudEventData.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.cloudevents;
 
 /**

--- a/api/src/main/java/io/cloudevents/rw/CloudEventDataMapper.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventDataMapper.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.cloudevents.rw;
 
 import io.cloudevents.CloudEventData;

--- a/api/src/main/java/io/cloudevents/rw/CloudEventDataMapper.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventDataMapper.java
@@ -1,0 +1,23 @@
+package io.cloudevents.rw;
+
+import io.cloudevents.CloudEventData;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Interface to convert a {@link CloudEventData} instance to another one.
+ */
+@FunctionalInterface
+@ParametersAreNonnullByDefault
+public interface CloudEventDataMapper {
+
+    /**
+     * Map {@code data} to another {@link CloudEventData} instance.
+     *
+     * @param data the input data
+     * @return The new data
+     * @throws CloudEventRWException is anything goes wrong while mapping the input data
+     */
+    CloudEventData map(CloudEventData data) throws CloudEventRWException;
+
+}

--- a/api/src/main/java/io/cloudevents/rw/CloudEventReader.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventReader.java
@@ -17,9 +17,14 @@
 
 package io.cloudevents.rw;
 
+import io.cloudevents.lang.Nullable;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
 /**
  * Represents an object that can be read as CloudEvent
  */
+@ParametersAreNonnullByDefault
 public interface CloudEventReader {
 
     /**
@@ -28,7 +33,14 @@ public interface CloudEventReader {
      * @param writerFactory a factory that generates a visitor starting from the SpecVersion of the event
      * @throws CloudEventRWException if something went wrong during the visit.
      */
-    <V extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<V, R> writerFactory) throws CloudEventRWException;
+    default <V extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<V, R> writerFactory) throws CloudEventRWException {
+        return read(writerFactory, null);
+    }
+
+    /**
+     * Like {@link CloudEventReader#read(CloudEventWriterFactory)}, but providing a mapper for {@link io.cloudevents.CloudEventData} to be invoked when the data field is available.
+     */
+    <V extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<V, R> writerFactory, @Nullable CloudEventDataMapper mapper) throws CloudEventRWException;
 
     /**
      * Visit self attributes using the provided writer

--- a/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
@@ -261,4 +261,22 @@ public interface CloudEventBuilder extends CloudEventWriter<CloudEvent> {
         );
     }
 
+    /**
+     * Create a new builder starting from the values of the provided event.
+     *
+     * @param event event to copy values from
+     * @return the new builder
+     */
+    static CloudEventBuilder from(@Nonnull CloudEvent event) {
+        switch (event.getSpecVersion()) {
+            case V1:
+                return CloudEventBuilder.v1(event);
+            case V03:
+                return CloudEventBuilder.v03(event);
+        }
+        throw new IllegalStateException(
+            "The provided spec version doesn't exist. Please make sure your io.cloudevents deps versions are aligned."
+        );
+    }
+
 }

--- a/core/src/main/java/io/cloudevents/core/format/EventFormat.java
+++ b/core/src/main/java/io/cloudevents/core/format/EventFormat.java
@@ -54,7 +54,9 @@ public interface EventFormat {
      * @return the deserialized event.
      * @throws EventDeserializationException if something goes wrong during deserialization.
      */
-    CloudEvent deserialize(byte[] bytes) throws EventDeserializationException;
+    default CloudEvent deserialize(byte[] bytes) throws EventDeserializationException {
+        return this.deserialize(bytes, null);
+    }
 
     /**
      * Like {@link EventFormat#deserialize(byte[])}, but allows a mapper that maps the parsed {@link io.cloudevents.CloudEventData} to another one.

--- a/core/src/main/java/io/cloudevents/core/format/EventFormat.java
+++ b/core/src/main/java/io/cloudevents/core/format/EventFormat.java
@@ -18,6 +18,8 @@
 package io.cloudevents.core.format;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.lang.Nullable;
+import io.cloudevents.rw.CloudEventDataMapper;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Collections;
@@ -53,6 +55,11 @@ public interface EventFormat {
      * @throws EventDeserializationException if something goes wrong during deserialization.
      */
     CloudEvent deserialize(byte[] bytes) throws EventDeserializationException;
+
+    /**
+     * Like {@link EventFormat#deserialize(byte[])}, but allows a mapper that maps the parsed {@link io.cloudevents.CloudEventData} to another one.
+     */
+    CloudEvent deserialize(byte[] bytes, @Nullable CloudEventDataMapper mapper) throws EventDeserializationException;
 
     /**
      * @return the set of content types this event format can deserialize. These content types are used

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEvent.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEvent.java
@@ -50,13 +50,13 @@ public abstract class BaseCloudEvent implements CloudEvent, CloudEventReader {
         return this.extensions.keySet();
     }
 
-    public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory) throws CloudEventRWException, IllegalStateException {
+    public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory, CloudEventDataMapper mapper) throws CloudEventRWException, IllegalStateException {
         CloudEventWriter<V> visitor = writerFactory.create(this.getSpecVersion());
         this.readAttributes(visitor);
         this.readExtensions(visitor);
 
         if (this.data != null) {
-            return visitor.end(this.data);
+            return visitor.end(mapper != null ? mapper.map(this.data) : this.data);
         }
 
         return visitor.end();

--- a/core/src/main/java/io/cloudevents/core/impl/CloudEventReaderAdapter.java
+++ b/core/src/main/java/io/cloudevents/core/impl/CloudEventReaderAdapter.java
@@ -29,13 +29,13 @@ public class CloudEventReaderAdapter implements CloudEventReader {
     }
 
     @Override
-    public <V extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<V, R> writerFactory) throws RuntimeException {
+    public <V extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<V, R> writerFactory, CloudEventDataMapper mapper) throws RuntimeException {
         CloudEventWriter<R> visitor = writerFactory.create(event.getSpecVersion());
         this.readAttributes(visitor);
         this.readExtensions(visitor);
 
         if (event.getData() != null) {
-            return visitor.end(event.getData());
+            return visitor.end(mapper != null ? mapper.map(event.getData()) : event.getData());
         }
 
         return visitor.end();

--- a/core/src/main/java/io/cloudevents/core/message/StructuredMessageReader.java
+++ b/core/src/main/java/io/cloudevents/core/message/StructuredMessageReader.java
@@ -20,6 +20,8 @@ package io.cloudevents.core.message;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.message.impl.GenericStructuredMessageReader;
+import io.cloudevents.lang.Nullable;
+import io.cloudevents.rw.CloudEventDataMapper;
 import io.cloudevents.rw.CloudEventRWException;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -40,6 +42,10 @@ public interface StructuredMessageReader {
 
     default CloudEvent toEvent() throws CloudEventRWException, IllegalStateException {
         return this.read(EventFormat::deserialize);
+    }
+
+    default CloudEvent toEvent(@Nullable CloudEventDataMapper mapper) throws CloudEventRWException, IllegalStateException {
+        return this.read((format, value) -> format.deserialize(value, mapper));
     }
 
     /**

--- a/core/src/main/java/io/cloudevents/core/message/impl/BaseGenericBinaryMessageReaderImpl.java
+++ b/core/src/main/java/io/cloudevents/core/message/impl/BaseGenericBinaryMessageReaderImpl.java
@@ -44,7 +44,7 @@ public abstract class BaseGenericBinaryMessageReaderImpl<HK, HV> extends BaseBin
     }
 
     @Override
-    public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory) throws CloudEventRWException, IllegalStateException {
+    public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory, CloudEventDataMapper mapper) throws CloudEventRWException, IllegalStateException {
         CloudEventWriter<V> visitor = writerFactory.create(this.version);
 
         // Grab from headers the attributes and extensions
@@ -68,7 +68,7 @@ public abstract class BaseGenericBinaryMessageReaderImpl<HK, HV> extends BaseBin
 
         // Set the payload
         if (this.body != null) {
-            return visitor.end(this.body);
+            return visitor.end(mapper != null ? mapper.map(this.body) : this.body);
         }
 
         return visitor.end();

--- a/core/src/main/java/io/cloudevents/core/message/impl/BaseStructuredMessageReader.java
+++ b/core/src/main/java/io/cloudevents/core/message/impl/BaseStructuredMessageReader.java
@@ -19,10 +19,7 @@ package io.cloudevents.core.message.impl;
 
 import io.cloudevents.core.message.Encoding;
 import io.cloudevents.core.message.MessageReader;
-import io.cloudevents.rw.CloudEventAttributesWriter;
-import io.cloudevents.rw.CloudEventExtensionsWriter;
-import io.cloudevents.rw.CloudEventWriter;
-import io.cloudevents.rw.CloudEventWriterFactory;
+import io.cloudevents.rw.*;
 
 public abstract class BaseStructuredMessageReader implements MessageReader {
 
@@ -32,7 +29,7 @@ public abstract class BaseStructuredMessageReader implements MessageReader {
     }
 
     @Override
-    public <V extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<V, R> writerFactory) {
+    public <V extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<V, R> writerFactory, CloudEventDataMapper mapper) {
         throw MessageUtils.generateWrongEncoding(Encoding.BINARY, Encoding.STRUCTURED);
     }
 

--- a/core/src/main/java/io/cloudevents/core/message/impl/UnknownEncodingMessageReader.java
+++ b/core/src/main/java/io/cloudevents/core/message/impl/UnknownEncodingMessageReader.java
@@ -29,7 +29,7 @@ public class UnknownEncodingMessageReader implements MessageReader {
     }
 
     @Override
-    public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory) throws CloudEventRWException, IllegalStateException {
+    public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory, CloudEventDataMapper mapper) throws CloudEventRWException, IllegalStateException {
         throw new IllegalStateException("Unknown encoding");
     }
 

--- a/core/src/test/java/io/cloudevents/core/mock/MockBinaryMessageWriter.java
+++ b/core/src/test/java/io/cloudevents/core/mock/MockBinaryMessageWriter.java
@@ -62,7 +62,7 @@ public class MockBinaryMessageWriter extends BaseBinaryMessageReader implements 
     }
 
     @Override
-    public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory) throws CloudEventRWException, IllegalStateException {
+    public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory, CloudEventDataMapper mapper) throws CloudEventRWException, IllegalStateException {
         if (version == null) {
             throw new IllegalStateException("MockBinaryMessage is empty");
         }
@@ -72,7 +72,7 @@ public class MockBinaryMessageWriter extends BaseBinaryMessageReader implements 
         this.readExtensions(visitor);
 
         if (this.data != null) {
-            return visitor.end(this.data);
+            return visitor.end(mapper != null ? mapper.map(this.data) : this.data);
         }
 
         return visitor.end();

--- a/core/src/test/java/io/cloudevents/core/mock/MyCloudEventData.java
+++ b/core/src/test/java/io/cloudevents/core/mock/MyCloudEventData.java
@@ -2,6 +2,8 @@ package io.cloudevents.core.mock;
 
 import io.cloudevents.CloudEventData;
 
+import java.util.Objects;
+
 public class MyCloudEventData implements CloudEventData {
 
     private final int value;
@@ -19,7 +21,21 @@ public class MyCloudEventData implements CloudEventData {
         return value;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MyCloudEventData that = (MyCloudEventData) o;
+        return getValue() == that.getValue();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+
     public static MyCloudEventData fromStringBytes(byte[] bytes) {
         return new MyCloudEventData(Integer.valueOf(new String(bytes)));
     }
+
 }

--- a/core/src/test/java/io/cloudevents/core/mock/MyCloudEventData.java
+++ b/core/src/test/java/io/cloudevents/core/mock/MyCloudEventData.java
@@ -1,0 +1,25 @@
+package io.cloudevents.core.mock;
+
+import io.cloudevents.CloudEventData;
+
+public class MyCloudEventData implements CloudEventData {
+
+    private final int value;
+
+    public MyCloudEventData(int value) {
+        this.value = value;
+    }
+
+    @Override
+    public byte[] toBytes() {
+        return Integer.toString(value).getBytes();
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static MyCloudEventData fromStringBytes(byte[] bytes) {
+        return new MyCloudEventData(Integer.valueOf(new String(bytes)));
+    }
+}

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -54,7 +54,7 @@ public class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
         }
 
         @Override
-        public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory) throws CloudEventRWException, IllegalStateException {
+        public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory, CloudEventDataMapper mapper) throws CloudEventRWException, IllegalStateException {
             try {
                 SpecVersion specVersion = SpecVersion.parse(getStringNode(this.node, this.p, "specversion"));
                 CloudEventWriter<V> visitor = writerFactory.create(specVersion);
@@ -144,7 +144,7 @@ public class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
                 });
 
                 if (data != null) {
-                    return visitor.end(data);
+                    return visitor.end(mapper != null ? mapper.map(data) : data);
                 }
                 return visitor.end();
             } catch (IOException e) {

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.cloudevents.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonCloudEventDataTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonCloudEventDataTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.jackson;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.mock.MyCloudEventData;
+import io.cloudevents.core.provider.EventFormatProvider;
+import io.cloudevents.core.test.Data;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonCloudEventDataTest {
+
+    @Test
+    public void testMapper() {
+        CloudEvent event = CloudEventBuilder.v1(Data.V1_MIN)
+            .withData("application/json", new JsonCloudEventData(JsonNodeFactory.instance.numberNode(10)))
+            .build();
+
+        byte[] serialized = EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE)
+            .serialize(event);
+
+        CloudEvent deserialized = EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE)
+            .deserialize(serialized, data -> {
+                assertThat(data)
+                    .isInstanceOf(JsonCloudEventData.class);
+                assertThat(((JsonCloudEventData) data).getNode().isInt())
+                    .isTrue();
+                return new MyCloudEventData(((JsonCloudEventData) data).getNode().asInt());
+            });
+
+        assertThat(deserialized.getData())
+            .isInstanceOf(MyCloudEventData.class);
+        assertThat(((MyCloudEventData) deserialized.getData()).getValue())
+            .isEqualTo(10);
+    }
+
+}


### PR DESCRIPTION
This PR introduces an interface to perform the mapping of `CloudEventData` and integrates it in the read process.

Now the user, when reading an event, can provide a mapper that converts the parsed `CloudEventData`, in whatever shape it is, to the desired data payload. **The mapper is consistently invoked both when messages are in structured mode or binary mode**: in this way, users define their own `CloudEventData`, along with `CloudEventDataMapper`, and they can consistently access to the event payloads, no matter from which "medium" the event came from.
When message is transcoded from one message to another, without going through `Event` (look at `MessageReader#visit` method), the mapper is not invoked.

Because we reuse `CloudEventData`, the user can eventually develop optimizations in this mapper (e.g. if data is instance of `JsonCloudEventData`, then faster mapping to my pojo, etc).

Also introduces `CloudEventBuilder#from` static method to simplify copying events.

Among the other usability issues, this fixes #238, in the sense that now users can finally provide a mapper in the kafka `CloudEventDeserializer` to map data to their business object (e.g. `CloudEventDataMapper` can implement the conversion data in avro format -> business object)

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>