### PR TITLE
CloudEventUtils.mapData(event, mapper)

### DIFF
--- a/api/src/main/java/io/cloudevents/CloudEvent.java
+++ b/api/src/main/java/io/cloudevents/CloudEvent.java
@@ -17,7 +17,6 @@
 package io.cloudevents;
 
 import io.cloudevents.lang.Nullable;
-import io.cloudevents.rw.CloudEventDataMapper;
 
 /**
  * Interface representing an in memory read only representation of a CloudEvent,
@@ -30,16 +29,4 @@ public interface CloudEvent extends CloudEventAttributes, CloudEventExtensions {
      */
     @Nullable
     CloudEventData getData();
-
-    /**
-     * Get the data contained in this event and map it using the provided mapper.
-     */
-    @Nullable
-    default <R extends CloudEventData> R toData(CloudEventDataMapper<R> mapper) {
-        CloudEventData data = getData();
-        if (data == null) {
-            return null;
-        }
-        return mapper.map(data);
-    }
 }

--- a/api/src/main/java/io/cloudevents/CloudEvent.java
+++ b/api/src/main/java/io/cloudevents/CloudEvent.java
@@ -17,6 +17,7 @@
 package io.cloudevents;
 
 import io.cloudevents.lang.Nullable;
+import io.cloudevents.rw.CloudEventDataMapper;
 
 /**
  * Interface representing an in memory read only representation of a CloudEvent,
@@ -29,4 +30,16 @@ public interface CloudEvent extends CloudEventAttributes, CloudEventExtensions {
      */
     @Nullable
     CloudEventData getData();
+
+    /**
+     * Get the data contained in this event and map it using the provided mapper.
+     */
+    @Nullable
+    default <R extends CloudEventData> R toData(CloudEventDataMapper<R> mapper) {
+        CloudEventData data = getData();
+        if (data == null) {
+            return null;
+        }
+        return mapper.map(data);
+    }
 }

--- a/api/src/main/java/io/cloudevents/rw/CloudEventDataMapper.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventDataMapper.java
@@ -26,7 +26,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 @FunctionalInterface
 @ParametersAreNonnullByDefault
-public interface CloudEventDataMapper {
+public interface CloudEventDataMapper<R extends CloudEventData> {
 
     /**
      * Map {@code data} to another {@link CloudEventData} instance.
@@ -35,6 +35,6 @@ public interface CloudEventDataMapper {
      * @return The new data
      * @throws CloudEventRWException is anything goes wrong while mapping the input data
      */
-    CloudEventData map(CloudEventData data) throws CloudEventRWException;
+    R map(CloudEventData data) throws CloudEventRWException;
 
 }

--- a/core/src/main/java/io/cloudevents/core/impl/CloudEventUtils.java
+++ b/core/src/main/java/io/cloudevents/core/impl/CloudEventUtils.java
@@ -46,7 +46,7 @@ public final class CloudEventUtils {
      * Get the data contained in {@code event} and map it using the provided mapper.
      */
     @Nullable
-    <R extends CloudEventData> R mapData(CloudEvent event, CloudEventDataMapper<R> mapper) {
+    public static <R extends CloudEventData> R mapData(CloudEvent event, CloudEventDataMapper<R> mapper) {
         CloudEventData data = event.getData();
         if (data == null) {
             return null;

--- a/core/src/main/java/io/cloudevents/core/impl/CloudEventUtils.java
+++ b/core/src/main/java/io/cloudevents/core/impl/CloudEventUtils.java
@@ -18,6 +18,9 @@
 package io.cloudevents.core.impl;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.lang.Nullable;
+import io.cloudevents.rw.CloudEventDataMapper;
 import io.cloudevents.rw.CloudEventReader;
 
 public final class CloudEventUtils {
@@ -37,6 +40,18 @@ public final class CloudEventUtils {
         } else {
             return new CloudEventReaderAdapter(event);
         }
+    }
+
+    /**
+     * Get the data contained in {@code event} and map it using the provided mapper.
+     */
+    @Nullable
+    <R extends CloudEventData> R mapData(CloudEvent event, CloudEventDataMapper<R> mapper) {
+        CloudEventData data = event.getData();
+        if (data == null) {
+            return null;
+        }
+        return mapper.map(data);
     }
 
 }

--- a/core/src/main/java/io/cloudevents/core/message/MessageReader.java
+++ b/core/src/main/java/io/cloudevents/core/message/MessageReader.java
@@ -18,6 +18,7 @@
 package io.cloudevents.core.message;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.lang.Nullable;
 import io.cloudevents.rw.*;
@@ -116,7 +117,7 @@ public interface MessageReader extends StructuredMessageReader, CloudEventReader
      * @throws CloudEventRWException if something went wrong during the visit.
      * @throws IllegalStateException if the message has an unknown encoding.
      */
-    default CloudEvent toEvent(@Nullable CloudEventDataMapper<?> mapper) throws CloudEventRWException, IllegalStateException {
+    default CloudEvent toEvent(@Nullable CloudEventDataMapper<? extends CloudEventData> mapper) throws CloudEventRWException, IllegalStateException {
         switch (getEncoding()) {
             case BINARY:
                 return this.read(CloudEventBuilder::fromSpecVersion, mapper);

--- a/core/src/main/java/io/cloudevents/core/message/MessageReader.java
+++ b/core/src/main/java/io/cloudevents/core/message/MessageReader.java
@@ -116,7 +116,7 @@ public interface MessageReader extends StructuredMessageReader, CloudEventReader
      * @throws CloudEventRWException if something went wrong during the visit.
      * @throws IllegalStateException if the message has an unknown encoding.
      */
-    default CloudEvent toEvent(@Nullable CloudEventDataMapper mapper) throws CloudEventRWException, IllegalStateException {
+    default CloudEvent toEvent(@Nullable CloudEventDataMapper<?> mapper) throws CloudEventRWException, IllegalStateException {
         switch (getEncoding()) {
             case BINARY:
                 return this.read(CloudEventBuilder::fromSpecVersion, mapper);

--- a/core/src/main/java/io/cloudevents/core/message/StructuredMessageReader.java
+++ b/core/src/main/java/io/cloudevents/core/message/StructuredMessageReader.java
@@ -44,7 +44,7 @@ public interface StructuredMessageReader {
         return this.read(EventFormat::deserialize);
     }
 
-    default CloudEvent toEvent(@Nullable CloudEventDataMapper mapper) throws CloudEventRWException, IllegalStateException {
+    default CloudEvent toEvent(@Nullable CloudEventDataMapper<?> mapper) throws CloudEventRWException, IllegalStateException {
         return this.read((format, value) -> format.deserialize(value, mapper));
     }
 

--- a/core/src/main/java/io/cloudevents/core/message/StructuredMessageReader.java
+++ b/core/src/main/java/io/cloudevents/core/message/StructuredMessageReader.java
@@ -18,6 +18,7 @@
 package io.cloudevents.core.message;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.message.impl.GenericStructuredMessageReader;
 import io.cloudevents.lang.Nullable;
@@ -44,7 +45,7 @@ public interface StructuredMessageReader {
         return this.read(EventFormat::deserialize);
     }
 
-    default CloudEvent toEvent(@Nullable CloudEventDataMapper<?> mapper) throws CloudEventRWException, IllegalStateException {
+    default CloudEvent toEvent(@Nullable CloudEventDataMapper<? extends CloudEventData> mapper) throws CloudEventRWException, IllegalStateException {
         return this.read((format, value) -> format.deserialize(value, mapper));
     }
 

--- a/core/src/test/java/io/cloudevents/core/impl/CloudEventUtilsTest.java
+++ b/core/src/test/java/io/cloudevents/core/impl/CloudEventUtilsTest.java
@@ -1,0 +1,59 @@
+package io.cloudevents.core.impl;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.mock.MyCloudEventData;
+import io.cloudevents.rw.CloudEventDataMapper;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CloudEventUtilsTest {
+
+    @Test
+    void mapDataWithNullData() {
+        AtomicInteger i = new AtomicInteger();
+        CloudEventDataMapper<CloudEventData> mapper = data -> {
+            i.incrementAndGet();
+            return data;
+        };
+
+        CloudEvent cloudEvent = CloudEventBuilder.v1()
+            .withId("aaa")
+            .withSource(URI.create("localhost"))
+            .withType("bbb")
+            .build();
+
+        assertThat(CloudEventUtils.mapData(cloudEvent, mapper))
+            .isNull();
+        assertThat(i)
+            .hasValue(0);
+    }
+
+    @Test
+    void mapData() {
+        AtomicInteger i = new AtomicInteger();
+        CloudEventDataMapper<CloudEventData> mapper = data -> {
+            i.incrementAndGet();
+            return data;
+        };
+
+        MyCloudEventData data = new MyCloudEventData(10);
+
+        CloudEvent cloudEvent = CloudEventBuilder.v1()
+            .withId("aaa")
+            .withSource(URI.create("localhost"))
+            .withType("bbb")
+            .withData(data)
+            .build();
+
+        assertThat(CloudEventUtils.mapData(cloudEvent, mapper))
+            .isEqualTo(data);
+        assertThat(i)
+            .hasValue(1);
+    }
+}


### PR DESCRIPTION
This PR adds a new method to `CloudEventUtils`, called `mapData(event, mapper)` (implemented by default), to improve the user experience with mappers. Now we finally have a good user experience for data: users can now safely map event payloads to business objects without casting and without any knowledge of the sdk itself:

```java
MyPojo myPojo = mapData(event, PojoCloudEventDataMapper.from(objectMapper, new TypeReference<MyPojo>() {})) // PojoCloudEventDataMapper<MyPojo>
  .getValue();
```

(note: this example is using json mapper which is proposed in another pr independent from this one)

To make this possible, I also generified the return value of CloudEventDataMapper

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>