### PR TITLE
Moved CloudEventUtils to io.cloudevents.core

### DIFF
--- a/core/src/main/java/io/cloudevents/core/CloudEventUtils.java
+++ b/core/src/main/java/io/cloudevents/core/CloudEventUtils.java
@@ -15,29 +15,36 @@
  *
  */
 
-package io.cloudevents.core.impl;
+package io.cloudevents.core;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.impl.CloudEventReaderAdapter;
 import io.cloudevents.lang.Nullable;
 import io.cloudevents.rw.CloudEventContextReader;
 import io.cloudevents.rw.CloudEventDataMapper;
+import io.cloudevents.rw.CloudEventRWException;
 import io.cloudevents.rw.CloudEventReader;
 
+/**
+ * This class contains a set of utility methods to deal with conversions of io.cloudevents related interfaces
+ */
 public final class CloudEventUtils {
 
     private CloudEventUtils() {}
 
     /**
      * Convert a {@link CloudEvent} to a {@link CloudEventReader}. This method provides a default implementation
+     * for CloudEvent that doesn't implement {@link CloudEventReader}
      * for CloudEvent that doesn't implement CloudEventVisitable.
      * <p>
      * It's safe to use the returned {@link CloudEventReader} multiple times.
      *
      * @param event the event to convert
-     * @return the visitable implementation
+     * @return the reader implementation
      */
-    public static CloudEventReader toVisitable(CloudEvent event) {
+    public static CloudEventReader toReader(CloudEvent event) {
         if (event instanceof CloudEventReader) {
             return (CloudEventReader) event;
         } else {
@@ -60,6 +67,27 @@ public final class CloudEventUtils {
         } else {
             return new CloudEventReaderAdapter(event);
         }
+    }
+
+    /**
+     * Convert a {@link CloudEventReader} to a {@link CloudEvent}.
+     *
+     * @param reader the reader where to read the message from
+     * @return the reader implementation
+     */
+    public static CloudEvent toEvent(CloudEventReader reader) throws CloudEventRWException {
+        return toEvent(reader, null);
+    }
+
+    /**
+     * Convert a {@link CloudEventReader} to a {@link CloudEvent} mapping the data with the provided {@code mapper}.
+     *
+     * @param reader the reader where to read the message from
+     * @param mapper the mapper to use when reading the data
+     * @return the reader implementation
+     */
+    public static CloudEvent toEvent(CloudEventReader reader, @Nullable CloudEventDataMapper<?> mapper) throws CloudEventRWException {
+        return reader.read(CloudEventBuilder::fromSpecVersion, mapper);
     }
 
     /**

--- a/core/src/main/java/io/cloudevents/core/impl/CloudEventReaderAdapter.java
+++ b/core/src/main/java/io/cloudevents/core/impl/CloudEventReaderAdapter.java
@@ -24,7 +24,7 @@ public class CloudEventReaderAdapter implements CloudEventReader, CloudEventCont
 
     private final CloudEvent event;
 
-    CloudEventReaderAdapter(CloudEvent event) {
+    public CloudEventReaderAdapter(CloudEvent event) {
         this.event = event;
     }
 

--- a/core/src/main/java/io/cloudevents/core/message/MessageReader.java
+++ b/core/src/main/java/io/cloudevents/core/message/MessageReader.java
@@ -19,7 +19,7 @@ package io.cloudevents.core.message;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
-import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.CloudEventUtils;
 import io.cloudevents.lang.Nullable;
 import io.cloudevents.rw.*;
 
@@ -102,7 +102,7 @@ public interface MessageReader extends StructuredMessageReader, CloudEventReader
     default CloudEvent toEvent(@Nullable CloudEventDataMapper<? extends CloudEventData> mapper) throws CloudEventRWException, IllegalStateException {
         switch (getEncoding()) {
             case BINARY:
-                return this.read(CloudEventBuilder::fromSpecVersion, mapper);
+                return CloudEventUtils.toEvent(this, mapper);
             case STRUCTURED:
                 return this.read((format, value) -> format.deserialize(value, mapper));
             default:

--- a/core/src/main/java/io/cloudevents/core/message/MessageWriter.java
+++ b/core/src/main/java/io/cloudevents/core/message/MessageWriter.java
@@ -18,8 +18,8 @@
 package io.cloudevents.core.message;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.core.CloudEventUtils;
 import io.cloudevents.core.format.EventFormat;
-import io.cloudevents.core.impl.CloudEventUtils;
 import io.cloudevents.core.message.impl.GenericStructuredMessageReader;
 import io.cloudevents.rw.CloudEventWriter;
 import io.cloudevents.rw.CloudEventWriterFactory;
@@ -68,7 +68,7 @@ public interface MessageWriter<CEV extends CloudEventWriter<R>, R> extends Cloud
      * @return return value at the end of the write process.
      */
     default R writeBinary(CloudEvent event) {
-        return CloudEventUtils.toVisitable(event).read(this);
+        return CloudEventUtils.toReader(event).read(this);
     }
 
 }

--- a/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
@@ -17,8 +17,8 @@
 package io.cloudevents.core.v03;
 
 import io.cloudevents.SpecVersion;
+import io.cloudevents.core.CloudEventUtils;
 import io.cloudevents.core.impl.BaseCloudEventBuilder;
-import io.cloudevents.core.impl.CloudEventUtils;
 import io.cloudevents.rw.CloudEventRWException;
 import io.cloudevents.types.Time;
 

--- a/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
@@ -19,8 +19,8 @@ package io.cloudevents.core.v1;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.core.CloudEventUtils;
 import io.cloudevents.core.impl.BaseCloudEventBuilder;
-import io.cloudevents.core.impl.CloudEventUtils;
 import io.cloudevents.rw.CloudEventRWException;
 import io.cloudevents.types.Time;
 

--- a/core/src/test/java/io/cloudevents/core/CloudEventUtilsTest.java
+++ b/core/src/test/java/io/cloudevents/core/CloudEventUtilsTest.java
@@ -1,4 +1,4 @@
-package io.cloudevents.core.impl;
+package io.cloudevents.core;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;

--- a/core/src/test/java/io/cloudevents/core/mock/MockBinaryMessageWriter.java
+++ b/core/src/test/java/io/cloudevents/core/mock/MockBinaryMessageWriter.java
@@ -20,8 +20,8 @@ package io.cloudevents.core.mock;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.core.CloudEventUtils;
 import io.cloudevents.core.data.BytesCloudEventData;
-import io.cloudevents.core.impl.CloudEventUtils;
 import io.cloudevents.core.message.MessageReader;
 import io.cloudevents.core.message.impl.BaseBinaryMessageReader;
 import io.cloudevents.rw.*;
@@ -57,7 +57,7 @@ public class MockBinaryMessageWriter extends BaseBinaryMessageReader implements 
     public MockBinaryMessageWriter(CloudEvent event) {
         this();
         CloudEventUtils
-            .toVisitable(event)
+            .toReader(event)
             .read(this);
     }
 

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
-import io.cloudevents.core.impl.CloudEventUtils;
+import io.cloudevents.core.CloudEventUtils;
 import io.cloudevents.rw.CloudEventAttributesWriter;
 import io.cloudevents.rw.CloudEventContextReader;
 import io.cloudevents.rw.CloudEventExtensionsWriter;

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/PojoCloudEventDataMapperTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/PojoCloudEventDataMapperTest.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.cloudevents.CloudEvent;
+import io.cloudevents.core.CloudEventUtils;
 import io.cloudevents.core.builder.CloudEventBuilder;
-import io.cloudevents.core.impl.CloudEventUtils;
 import io.cloudevents.core.test.Data;
 import org.junit.jupiter.api.Test;
 

--- a/kafka/src/test/java/io/cloudevents/kafka/CloudEventMessageSerializerTest.java
+++ b/kafka/src/test/java/io/cloudevents/kafka/CloudEventMessageSerializerTest.java
@@ -18,7 +18,7 @@
 package io.cloudevents.kafka;
 
 import io.cloudevents.CloudEvent;
-import io.cloudevents.core.impl.CloudEventUtils;
+import io.cloudevents.core.CloudEventUtils;
 import io.cloudevents.core.message.Encoding;
 import io.cloudevents.core.message.MessageReader;
 import io.cloudevents.core.mock.MockBinaryMessageWriter;
@@ -41,7 +41,7 @@ public class CloudEventMessageSerializerTest {
         Headers headers = new RecordHeaders();
 
         MockBinaryMessageWriter inMessage = new MockBinaryMessageWriter();
-        CloudEventUtils.toVisitable(event).read(inMessage);
+        CloudEventUtils.toReader(event).read(inMessage);
 
         byte[] payload = serializer.serialize(topic, headers, inMessage);
 


### PR DESCRIPTION
Because `CloudEventUtils` now contains utilities useful to deal with conversions, often useful for end users of the sdk (look at `mapData`), I think it's reasonable to make it more visible and push it in the main package `cloudevents-core`.

Also:

* Renamed `CloudEventUtils#toVisitable` to `CloudEventUtils#toReader`
* Added `CloudEventUtils#toEvent` methods to convert a `CloudEventReader` to a `CloudEvent`

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>