### PR TITLE
CloudEventAttributesWriter/CloudEventExtensionsWriter accepts only non null values

### DIFF
--- a/api/src/main/java/io/cloudevents/rw/CloudEventAttributesWriter.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventAttributesWriter.java
@@ -17,7 +17,6 @@
 
 package io.cloudevents.rw;
 
-import io.cloudevents.lang.Nullable;
 import io.cloudevents.types.Time;
 
 import java.net.URI;
@@ -37,29 +36,29 @@ public interface CloudEventAttributesWriter {
      * @return self
      * @throws CloudEventRWException if anything goes wrong while writing this attribute.
      */
-    CloudEventAttributesWriter withAttribute(String name, @Nullable String value) throws CloudEventRWException;
+    CloudEventAttributesWriter withAttribute(String name, String value) throws CloudEventRWException;
 
     /**
      * Set attribute with type {@link URI}.
      *
-     * @param name name of the attribute
+     * @param name  name of the attribute
      * @param value value of the attribute
-     * @throws CloudEventRWException if anything goes wrong while writing this attribute.
      * @return self
+     * @throws CloudEventRWException if anything goes wrong while writing this attribute.
      */
-    default CloudEventAttributesWriter withAttribute(String name, @Nullable URI value) throws CloudEventRWException {
+    default CloudEventAttributesWriter withAttribute(String name, URI value) throws CloudEventRWException {
         return withAttribute(name, value == null ? null : value.toString());
     }
 
     /**
      * Set attribute with type {@link OffsetDateTime} attribute.
      *
-     * @param name name of the attribute
+     * @param name  name of the attribute
      * @param value value of the attribute
-     * @throws CloudEventRWException if anything goes wrong while writing this attribute.
      * @return self
+     * @throws CloudEventRWException if anything goes wrong while writing this attribute.
      */
-    default CloudEventAttributesWriter withAttribute(String name, @Nullable OffsetDateTime value) throws CloudEventRWException {
+    default CloudEventAttributesWriter withAttribute(String name, OffsetDateTime value) throws CloudEventRWException {
         return withAttribute(name, value == null ? null : Time.writeTime(name, value));
     }
 

--- a/api/src/main/java/io/cloudevents/rw/CloudEventExtensionsWriter.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventExtensionsWriter.java
@@ -17,8 +17,6 @@
 
 package io.cloudevents.rw;
 
-import io.cloudevents.lang.Nullable;
-
 import java.net.URI;
 
 /**
@@ -34,29 +32,29 @@ public interface CloudEventExtensionsWriter {
      * @return self
      * @throws CloudEventRWException if anything goes wrong while writing this extension.
      */
-    CloudEventExtensionsWriter withExtension(String name, @Nullable String value) throws CloudEventRWException;
+    CloudEventExtensionsWriter withExtension(String name, String value) throws CloudEventRWException;
 
     /**
      * Set attribute with type {@link URI}.
      *
-     * @param name name of the extension
+     * @param name  name of the extension
      * @param value value of the extension
-     * @throws CloudEventRWException if anything goes wrong while writing this extension.
      * @return self
+     * @throws CloudEventRWException if anything goes wrong while writing this extension.
      */
-    default CloudEventExtensionsWriter withExtension(String name, @Nullable Number value) throws CloudEventRWException {
+    default CloudEventExtensionsWriter withExtension(String name, Number value) throws CloudEventRWException {
         return withExtension(name, value == null ? null : value.toString());
     }
 
     /**
      * Set attribute with type {@link Boolean} attribute.
      *
-     * @param name name of the extension
+     * @param name  name of the extension
      * @param value value of the extension
-     * @throws CloudEventRWException if anything goes wrong while writing this extension.
      * @return self
+     * @throws CloudEventRWException if anything goes wrong while writing this extension.
      */
-    default CloudEventExtensionsWriter withExtension(String name, @Nullable Boolean value) throws CloudEventRWException {
+    default CloudEventExtensionsWriter withExtension(String name, Boolean value) throws CloudEventRWException {
         return withExtension(name, value == null ? null : value.toString());
     }
 

--- a/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
@@ -152,7 +152,7 @@ public interface CloudEventBuilder extends CloudEventWriter<CloudEvent> {
      * @return self
      */
     @Override
-    CloudEventBuilder withExtension(@Nonnull String key, String value);
+    CloudEventBuilder withExtension(@Nonnull String key, @Nonnull String value);
 
     /**
      * Set an extension with provided key and numeric value
@@ -162,7 +162,7 @@ public interface CloudEventBuilder extends CloudEventWriter<CloudEvent> {
      * @return self
      */
     @Override
-    CloudEventBuilder withExtension(@Nonnull String key, Number value);
+    CloudEventBuilder withExtension(@Nonnull String key, @Nonnull Number value);
 
     /**
      * Set an extension with provided key and boolean value
@@ -172,7 +172,7 @@ public interface CloudEventBuilder extends CloudEventWriter<CloudEvent> {
      * @return self
      */
     @Override
-    CloudEventBuilder withExtension(@Nonnull String key, Boolean value);
+    CloudEventBuilder withExtension(@Nonnull String key, @Nonnull Boolean value);
 
     /**
      * Add to the builder all the extension key/values of the provided extension

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -96,24 +96,24 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
         return this.self;
     }
 
-    public SELF withExtension(@Nonnull String key, String value) {
-        if(!isValidExtensionName(key)){
+    public SELF withExtension(@Nonnull String key, @Nonnull String value) {
+        if (!isValidExtensionName(key)) {
             throw CloudEventRWException.newInvalidExtensionName(key);
         }
         this.extensions.put(key, value);
         return self;
     }
 
-    public SELF withExtension(@Nonnull String key, Number value) {
-        if(!isValidExtensionName(key)){
+    public SELF withExtension(@Nonnull String key, @Nonnull Number value) {
+        if (!isValidExtensionName(key)) {
             throw CloudEventRWException.newInvalidExtensionName(key);
         }
         this.extensions.put(key, value);
         return self;
     }
 
-    public SELF withExtension(@Nonnull String key, Boolean value) {
-        if(!isValidExtensionName(key)){
+    public SELF withExtension(@Nonnull String key, @Nonnull Boolean value) {
+        if (!isValidExtensionName(key)) {
             throw CloudEventRWException.newInvalidExtensionName(key);
         }
         this.extensions.put(key, value);


### PR DESCRIPTION
This interface now better reflects the spec, because in the spec there isn't any concept of attribute exists but it's null.

Now the user of these interfaces (which are usually the `CloudEventReader`) should invoke `with[Attribute/Extension]` only and only if there such attribute/extension with a non null value. Depending on the event format/protocol binding, an error has to be throwed or the null value should just mean unset (like in JSON https://github.com/cloudevents/spec/pull/713).

Note that in the sdk we already followed this contract, so no surprise from our point of view, but for the user this is a breaking change.

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>