### PR TITLE
Add method `BytesCloudEventData#wrap`

### DIFF
--- a/amqp/src/main/java/io/cloudevents/amqp/impl/ProtonAmqpBinaryMessageReader.java
+++ b/amqp/src/main/java/io/cloudevents/amqp/impl/ProtonAmqpBinaryMessageReader.java
@@ -17,19 +17,18 @@
 
 package io.cloudevents.amqp.impl;
 
-import java.util.Objects;
-import java.util.function.BiConsumer;
-
-import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
-
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
 
 /**
  * An AMQP 1.0 message reader that can be read as a <em>CloudEvent</em>.
  * <p>
- * 
+ *
  * This reader reads sections of an AMQP message to construct a CloudEvent representation by doing the following:
  * <ul>
  *    <li> If the content-type property is set for an AMQP message, the value of the property
@@ -37,7 +36,7 @@ import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
  *    <li> If the (mandatory) application-properties of the AMQP message contains attributes and/or extentions,
  *         this reader will represent each property/extension as a cloud event attribute.
  * </ul>
- * 
+ *
  */
 public final class ProtonAmqpBinaryMessageReader extends BaseGenericBinaryMessageReaderImpl<String, Object> {
 
@@ -53,12 +52,12 @@ public final class ProtonAmqpBinaryMessageReader extends BaseGenericBinaryMessag
      *                                 The applicationProperties MUST not be {@code null}.
      * @param contentType              The content-type property of the AMQP message or {@code null} if the message content type is unknown.
      * @param payload                  The message payload or {@code null} if the message does not contain any payload.
-     * 
+     *
      * @throws NullPointerException if the applicationPropereties is {@code null}.
      */
-    public ProtonAmqpBinaryMessageReader(final SpecVersion version, final ApplicationProperties applicationProperties, 
-            final String contentType, final byte[] payload) {
-        super(version, payload != null && payload.length > 0 ? new BytesCloudEventData(payload) : null);
+    public ProtonAmqpBinaryMessageReader(final SpecVersion version, final ApplicationProperties applicationProperties,
+                                         final String contentType, final byte[] payload) {
+        super(version, payload != null && payload.length > 0 ? BytesCloudEventData.wrap(payload) : null);
         this.contentType = contentType;
         this.applicationProperties = Objects.requireNonNull(applicationProperties);
     }
@@ -70,7 +69,7 @@ public final class ProtonAmqpBinaryMessageReader extends BaseGenericBinaryMessag
 
     /**
      * Tests whether the given attribute key is prefixed with <em>cloudEvents:</em>
-     * 
+     *
      * @param key   The key to test for the presence of the prefix.
      * @return      True if the specified key starts with the prefix or
      *              false otherwise.
@@ -83,9 +82,9 @@ public final class ProtonAmqpBinaryMessageReader extends BaseGenericBinaryMessag
 
     /**
      * Gets the cloud event attribute key without the preceding prefix.
-     * 
+     *
      * @param key  The key containing the AMQP specific prefix.
-     * 
+     *
      * @return     The key without the prefix.
      */
     @Override
@@ -119,7 +118,7 @@ public final class ProtonAmqpBinaryMessageReader extends BaseGenericBinaryMessag
      * Gets the cloud event representation of the value.
      * <p>
      * This method simply returns the string representation of the type of value passed as argument.
-     * 
+     *
      * @param value The value of a CloudEvent attribute or extension.
      *
      * @return The string representation of the specified value.

--- a/core/src/main/java/io/cloudevents/core/data/BytesCloudEventData.java
+++ b/core/src/main/java/io/cloudevents/core/data/BytesCloudEventData.java
@@ -9,6 +9,9 @@ public class BytesCloudEventData implements CloudEventData {
 
     private final byte[] value;
 
+    /**
+     * @deprecated use {@link BytesCloudEventData#wrap(byte[])}
+     */
     public BytesCloudEventData(byte[] value) {
         Objects.requireNonNull(value);
         this.value = value;
@@ -37,5 +40,13 @@ public class BytesCloudEventData implements CloudEventData {
         return "BytesCloudEventData{" +
             "value=" + Arrays.toString(value) +
             '}';
+    }
+
+    /**
+     * @param value byte array to wrap
+     * @return byte array wrapped in a {@link BytesCloudEventData}, which implements {@link CloudEventData}.
+     */
+    public BytesCloudEventData wrap(byte[] value) {
+        return new BytesCloudEventData(value);
     }
 }

--- a/core/src/main/java/io/cloudevents/core/data/BytesCloudEventData.java
+++ b/core/src/main/java/io/cloudevents/core/data/BytesCloudEventData.java
@@ -46,7 +46,7 @@ public class BytesCloudEventData implements CloudEventData {
      * @param value byte array to wrap
      * @return byte array wrapped in a {@link BytesCloudEventData}, which implements {@link CloudEventData}.
      */
-    public BytesCloudEventData wrap(byte[] value) {
+    public static BytesCloudEventData wrap(byte[] value) {
         return new BytesCloudEventData(value);
     }
 }

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -68,7 +68,7 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     // to encode data
 
     public SELF withData(byte[] data) {
-        this.data = new BytesCloudEventData(data);
+        this.data = BytesCloudEventData.wrap(data);
         return this.self;
     }
 

--- a/core/src/test/java/io/cloudevents/core/mock/CSVFormat.java
+++ b/core/src/test/java/io/cloudevents/core/mock/CSVFormat.java
@@ -18,7 +18,6 @@
 package io.cloudevents.core.mock;
 
 import io.cloudevents.CloudEvent;
-import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.data.BytesCloudEventData;
@@ -60,7 +59,7 @@ public class CSVFormat implements EventFormat {
     }
 
     @Override
-    public CloudEvent deserialize(byte[] bytes, CloudEventDataMapper<? extends CloudEventData> mapper) {
+    public CloudEvent deserialize(byte[] bytes, CloudEventDataMapper mapper) {
         String[] splitted = new String(bytes, StandardCharsets.UTF_8).split(Pattern.quote(","));
         SpecVersion sv = SpecVersion.parse(splitted[0]);
 
@@ -91,7 +90,7 @@ public class CSVFormat implements EventFormat {
             builder.withTime(time);
         }
         if (data != null) {
-            builder.withData(mapper.map(new BytesCloudEventData(data)));
+            builder.withData(mapper.map(BytesCloudEventData.wrap(data)));
         }
         return builder.build();
     }

--- a/core/src/test/java/io/cloudevents/core/mock/MockBinaryMessageWriter.java
+++ b/core/src/test/java/io/cloudevents/core/mock/MockBinaryMessageWriter.java
@@ -46,7 +46,7 @@ public class MockBinaryMessageWriter extends BaseBinaryMessageReader implements 
     }
 
     public MockBinaryMessageWriter(SpecVersion version, Map<String, Object> attributes, byte[] data, Map<String, Object> extensions) {
-        this(version, attributes, new BytesCloudEventData(data), extensions);
+        this(version, attributes, BytesCloudEventData.wrap(data), extensions);
     }
 
     public MockBinaryMessageWriter() {

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -90,7 +90,7 @@ public class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
                         boolean isBase64 = "base64".equals(getOptionalStringNode(this.node, this.p, "datacontentencoding"));
                         if (node.has("data")) {
                             if (isBase64) {
-                                data = new BytesCloudEventData(node.remove("data").binaryValue());
+                                data = BytesCloudEventData.wrap(node.remove("data").binaryValue());
                             } else {
                                 if (JsonFormat.dataIsJsonContentType(contentType)) {
                                     // This solution is quite bad, but i see no alternatives now.
@@ -99,7 +99,7 @@ public class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
                                 } else {
                                     JsonNode dataNode = node.remove("data");
                                     assertNodeType(dataNode, JsonNodeType.STRING, "data", "Because content type is not a json, only a string is accepted as data");
-                                    data = new BytesCloudEventData(dataNode.asText().getBytes());
+                                    data = BytesCloudEventData.wrap(dataNode.asText().getBytes());
                                 }
                             }
                         }
@@ -108,7 +108,7 @@ public class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
                             throw MismatchedInputException.from(p, CloudEvent.class, "CloudEvent cannot have both 'data' and 'data_base64' fields");
                         }
                         if (node.has("data_base64")) {
-                            data = new BytesCloudEventData(node.remove("data_base64").binaryValue());
+                            data = BytesCloudEventData.wrap(node.remove("data_base64").binaryValue());
                         } else if (node.has("data")) {
                             if (JsonFormat.dataIsJsonContentType(contentType)) {
                                 // This solution is quite bad, but i see no alternatives now.
@@ -117,7 +117,7 @@ public class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
                             } else {
                                 JsonNode dataNode = node.remove("data");
                                 assertNodeType(dataNode, JsonNodeType.STRING, "data", "Because content type is not a json, only a string is accepted as data");
-                                data = new BytesCloudEventData(dataNode.asText().getBytes());
+                                data = BytesCloudEventData.wrap(dataNode.asText().getBytes());
                             }
                         }
                 }

--- a/http/basic/src/main/java/io/cloudevents/http/impl/HttpMessageReader.java
+++ b/http/basic/src/main/java/io/cloudevents/http/impl/HttpMessageReader.java
@@ -37,7 +37,7 @@ public class HttpMessageReader extends BaseGenericBinaryMessageReaderImpl<String
     }
 
     public HttpMessageReader(SpecVersion version, Consumer<BiConsumer<String, String>> forEachHeader, byte[] body) {
-        this(version, forEachHeader, body != null && body.length > 0 ? new BytesCloudEventData(body) : null);
+        this(version, forEachHeader, body != null && body.length > 0 ? BytesCloudEventData.wrap(body) : null);
     }
 
     @Override

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
@@ -33,7 +33,7 @@ public final class BinaryRestfulWSMessageReaderImpl extends BaseGenericBinaryMes
     private final MultivaluedMap<String, String> headers;
 
     public BinaryRestfulWSMessageReaderImpl(SpecVersion version, MultivaluedMap<String, String> headers, byte[] body) {
-        super(version, body != null && body.length > 0 ? new BytesCloudEventData(body) : null);
+        super(version, body != null && body.length > 0 ? BytesCloudEventData.wrap(body) : null);
 
         Objects.requireNonNull(headers);
         this.headers = headers;

--- a/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/BinaryVertxMessageReaderImpl.java
+++ b/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/BinaryVertxMessageReaderImpl.java
@@ -32,7 +32,7 @@ public class BinaryVertxMessageReaderImpl extends BaseGenericBinaryMessageReader
     private final MultiMap headers;
 
     public BinaryVertxMessageReaderImpl(SpecVersion version, MultiMap headers, Buffer body) {
-        super(version, body != null && body.length() > 0 ? new BytesCloudEventData(body.getBytes()) : null);
+        super(version, body != null && body.length() > 0 ? BytesCloudEventData.wrap(body.getBytes()) : null);
 
         Objects.requireNonNull(headers);
         this.headers = headers;

--- a/kafka/src/main/java/io/cloudevents/kafka/impl/KafkaBinaryMessageReaderImpl.java
+++ b/kafka/src/main/java/io/cloudevents/kafka/impl/KafkaBinaryMessageReaderImpl.java
@@ -31,7 +31,7 @@ public class KafkaBinaryMessageReaderImpl extends BaseGenericBinaryMessageReader
     private final Headers headers;
 
     public KafkaBinaryMessageReaderImpl(SpecVersion version, Headers headers, byte[] payload) {
-        super(version, payload != null && payload.length > 0 ? new BytesCloudEventData(payload) : null);
+        super(version, payload != null && payload.length > 0 ? BytesCloudEventData.wrap(payload) : null);
 
         Objects.requireNonNull(headers);
         this.headers = headers;


### PR DESCRIPTION
This is done to be consistent with #289. Also deprecating the constructor to force users to use the static method

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>