### PR TITLE
Introduce CloudEventContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ release.properties
 .classpath
 .project
 .settings/
+.vscode/
 
 # Log file
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ release.properties
 .project
 .settings/
 .vscode/
+.attach_pid*
 
 # Log file
 *.log

--- a/api/src/main/java/io/cloudevents/CloudEventContext.java
+++ b/api/src/main/java/io/cloudevents/CloudEventContext.java
@@ -16,17 +16,8 @@
  */
 package io.cloudevents;
 
-import io.cloudevents.lang.Nullable;
-
 /**
- * Interface representing an in memory read only representation of a CloudEvent,
- * as specified by the <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md">CloudEvents specification</a>
+ * Interface representing an in memory read only representation of CloudEvent attributes and extensions.
  */
-public interface CloudEvent extends CloudEventContext {
-
-    /**
-     * The event data
-     */
-    @Nullable
-    CloudEventData getData();
+public interface CloudEventContext extends CloudEventAttributes, CloudEventExtensions {
 }

--- a/core/src/main/java/io/cloudevents/core/CloudEventUtils.java
+++ b/core/src/main/java/io/cloudevents/core/CloudEventUtils.java
@@ -18,8 +18,10 @@
 package io.cloudevents.core;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventContext;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.impl.CloudEventContextReaderAdapter;
 import io.cloudevents.core.impl.CloudEventReaderAdapter;
 import io.cloudevents.lang.Nullable;
 import io.cloudevents.rw.CloudEventContextReader;
@@ -61,11 +63,11 @@ public final class CloudEventUtils {
      * @param event the event to convert
      * @return the context reader implementation
      */
-    public static CloudEventContextReader toContextReader(CloudEvent event) {
+    public static CloudEventContextReader toContextReader(CloudEventContext event) {
         if (event instanceof CloudEventContextReader) {
             return (CloudEventContextReader) event;
         } else {
-            return new CloudEventReaderAdapter(event);
+            return new CloudEventContextReaderAdapter(event);
         }
     }
 

--- a/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/builder/CloudEventBuilder.java
@@ -17,16 +17,18 @@
 
 package io.cloudevents.core.builder;
 
+import java.net.URI;
+import java.time.OffsetDateTime;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNullableByDefault;
+
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventContext;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.Extension;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.rw.CloudEventWriter;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNullableByDefault;
-import java.net.URI;
-import java.time.OffsetDateTime;
 
 /**
  * Builder interface to build a {@link CloudEvent}.
@@ -273,6 +275,24 @@ public interface CloudEventBuilder extends CloudEventWriter<CloudEvent> {
                 return CloudEventBuilder.v1(event);
             case V03:
                 return CloudEventBuilder.v03(event);
+        }
+        throw new IllegalStateException(
+            "The provided spec version doesn't exist. Please make sure your io.cloudevents deps versions are aligned."
+        );
+    }
+
+    /**
+     * Create a new builder starting from the values of the provided context.
+     *
+     * @param context context to copy values from
+     * @return the new builder
+     */
+    static CloudEventBuilder fromContext(@Nonnull CloudEventContext context) {
+        switch (context.getSpecVersion()) {
+            case V1:
+            return new io.cloudevents.core.v1.CloudEventBuilder(context);
+            case V03:
+            return new io.cloudevents.core.v03.CloudEventBuilder(context);
         }
         throw new IllegalStateException(
             "The provided spec version doesn't exist. Please make sure your io.cloudevents deps versions are aligned."

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEvent.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEvent.java
@@ -50,6 +50,7 @@ public abstract class BaseCloudEvent implements CloudEvent, CloudEventReader, Cl
         return this.extensions.keySet();
     }
 
+    @Override
     public <T extends CloudEventWriter<V>, V> V read(CloudEventWriterFactory<T, V> writerFactory, CloudEventDataMapper<? extends CloudEventData> mapper) throws CloudEventRWException, IllegalStateException {
         CloudEventWriter<V> visitor = writerFactory.create(this.getSpecVersion());
         this.readAttributes(visitor);

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -17,17 +17,19 @@
 
 package io.cloudevents.core.impl;
 
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
 import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventContext;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.Extension;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.data.BytesCloudEventData;
 import io.cloudevents.rw.CloudEventRWException;
-
-import javax.annotation.Nonnull;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<SELF, T>, T extends CloudEvent> implements CloudEventBuilder {
 
@@ -41,6 +43,20 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     public BaseCloudEventBuilder() {
         this.self = (SELF) this;
         this.extensions = new HashMap<>();
+    }
+
+    public BaseCloudEventBuilder(CloudEventContext context) {
+        this();
+        for (String name: context.getAttributeNames()) {
+            if (!name.equals("specversion")) {
+                Object value = context.getAttribute(name);
+                if (value instanceof String) {
+                    withAttribute(name, (String) value);
+                } else {
+                    withAttribute(name, value.toString());
+                }
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -38,38 +38,16 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
     private final SELF self;
 
     protected CloudEventData data;
-    protected Map<String, Object> extensions;
+    protected Map<String, Object> extensions = new HashMap<>();
 
     @SuppressWarnings("unchecked")
     public BaseCloudEventBuilder() {
         this.self = (SELF) this;
-        this.extensions = new HashMap<>();
     }
 
     public BaseCloudEventBuilder(CloudEventContext context) {
         this();
-        for (String name: context.getAttributeNames()) {
-            if (!name.equals("specversion")) {
-                Object value = context.getAttribute(name);
-                if (value instanceof String) {
-                    withAttribute(name, (String) value);
-                } else if (value instanceof URI) {
-                    withAttribute(name, (URI) value);
-                } else if (value instanceof OffsetDateTime) {
-                    withAttribute(name, (OffsetDateTime) value);
-                }
-            }
-        }
-        for (String name: context.getExtensionNames()) {
-            Object value = context.getExtension(name);
-            if (value instanceof String) {
-                withExtension(name, (String) value);
-            } else if (value instanceof Number) {
-                withExtension(name, (Number) value);
-            } else if (value instanceof Boolean) {
-                withExtension(name, (Boolean) value);
-            }
-        }
+        setAttributes(context);
     }
 
     @SuppressWarnings("unchecked")
@@ -84,7 +62,7 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
         }
     }
 
-    protected abstract void setAttributes(CloudEvent event);
+    protected abstract void setAttributes(CloudEventContext event);
 
     //TODO builder should accept data as Object and use data codecs (that we need to implement)
     // to encode data

--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -18,6 +18,7 @@
 package io.cloudevents.core.impl;
 
 import java.net.URI;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,9 +53,21 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
                 Object value = context.getAttribute(name);
                 if (value instanceof String) {
                     withAttribute(name, (String) value);
-                } else {
-                    withAttribute(name, value.toString());
+                } else if (value instanceof URI) {
+                    withAttribute(name, (URI) value);
+                } else if (value instanceof OffsetDateTime) {
+                    withAttribute(name, (OffsetDateTime) value);
                 }
+            }
+        }
+        for (String name: context.getExtensionNames()) {
+            Object value = context.getExtension(name);
+            if (value instanceof String) {
+                withExtension(name, (String) value);
+            } else if (value instanceof Number) {
+                withExtension(name, (Number) value);
+            } else if (value instanceof Boolean) {
+                withExtension(name, (Boolean) value);
             }
         }
     }

--- a/core/src/main/java/io/cloudevents/core/impl/CloudEventContextReaderAdapter.java
+++ b/core/src/main/java/io/cloudevents/core/impl/CloudEventContextReaderAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.core.impl;
+
+import io.cloudevents.CloudEventContext;
+import io.cloudevents.rw.CloudEventAttributesWriter;
+import io.cloudevents.rw.CloudEventContextReader;
+import io.cloudevents.rw.CloudEventExtensionsWriter;
+
+public class CloudEventContextReaderAdapter implements CloudEventContextReader {
+
+    private final CloudEventContext event;
+
+    public CloudEventContextReaderAdapter(CloudEventContext event) {
+        this.event = event;
+    }
+
+    @Override
+    public void readAttributes(CloudEventAttributesWriter writer) throws RuntimeException {
+        writer.withAttribute("id", event.getId());
+        writer.withAttribute("source", event.getSource());
+        writer.withAttribute("type", event.getType());
+        if (event.getDataContentType() != null) {
+            writer.withAttribute("datacontenttype", event.getDataContentType());
+        }
+        if (event.getDataSchema() != null) {
+            writer.withAttribute("dataschema", event.getDataSchema());
+        }
+        if (event.getSubject() != null) {
+            writer.withAttribute("subject", event.getSubject());
+        }
+        if (event.getTime() != null) {
+            writer.withAttribute("time", event.getTime());
+        }
+    }
+
+    @Override
+    public void readExtensions(CloudEventExtensionsWriter writer) throws RuntimeException {
+        for (String key : event.getExtensionNames()) {
+            Object value = event.getExtension(key);
+            if (value instanceof String) {
+                writer.withExtension(key, (String) value);
+            } else if (value instanceof Number) {
+                writer.withExtension(key, (Number) value);
+            } else if (value instanceof Boolean) {
+                writer.withExtension(key, (Boolean) value);
+            } else {
+                // This should never happen because we build that map only through our builders
+                throw new IllegalStateException("Illegal value inside extensions map: " + key + " " + value);
+            }
+        }
+        ;
+    }
+
+}

--- a/core/src/main/java/io/cloudevents/core/impl/CloudEventReaderAdapter.java
+++ b/core/src/main/java/io/cloudevents/core/impl/CloudEventReaderAdapter.java
@@ -25,8 +25,11 @@ public class CloudEventReaderAdapter implements CloudEventReader, CloudEventCont
 
     private final CloudEvent event;
 
+    private final CloudEventContextReader context;
+
     public CloudEventReaderAdapter(CloudEvent event) {
         this.event = event;
+        this.context = new CloudEventContextReaderAdapter(event);
     }
 
     @Override
@@ -44,39 +47,12 @@ public class CloudEventReaderAdapter implements CloudEventReader, CloudEventCont
 
     @Override
     public void readAttributes(CloudEventAttributesWriter writer) throws RuntimeException {
-        writer.withAttribute("id", event.getId());
-        writer.withAttribute("source", event.getSource());
-        writer.withAttribute("type", event.getType());
-        if (event.getDataContentType() != null) {
-            writer.withAttribute("datacontenttype", event.getDataContentType());
-        }
-        if (event.getDataSchema() != null) {
-            writer.withAttribute("dataschema", event.getDataSchema());
-        }
-        if (event.getSubject() != null) {
-            writer.withAttribute("subject", event.getSubject());
-        }
-        if (event.getTime() != null) {
-            writer.withAttribute("time", event.getTime());
-        }
+        context.readAttributes(writer);
     }
 
     @Override
     public void readExtensions(CloudEventExtensionsWriter writer) throws RuntimeException {
-        for (String key : event.getExtensionNames()) {
-            Object value = event.getExtension(key);
-            if (value instanceof String) {
-                writer.withExtension(key, (String) value);
-            } else if (value instanceof Number) {
-                writer.withExtension(key, (Number) value);
-            } else if (value instanceof Boolean) {
-                writer.withExtension(key, (Boolean) value);
-            } else {
-                // This should never happen because we build that map only through our builders
-                throw new IllegalStateException("Illegal value inside extensions map: " + key + " " + value);
-            }
-        }
-        ;
+        context.readExtensions(writer);
     }
 
 }

--- a/core/src/main/java/io/cloudevents/core/impl/CloudEventReaderAdapter.java
+++ b/core/src/main/java/io/cloudevents/core/impl/CloudEventReaderAdapter.java
@@ -21,19 +21,18 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.rw.*;
 
-public class CloudEventReaderAdapter implements CloudEventReader, CloudEventContextReader {
+public class CloudEventReaderAdapter extends CloudEventContextReaderAdapter implements CloudEventReader {
 
     private final CloudEvent event;
 
-    private final CloudEventContextReader context;
-
     public CloudEventReaderAdapter(CloudEvent event) {
+        super(event);
         this.event = event;
-        this.context = new CloudEventContextReaderAdapter(event);
     }
 
     @Override
-    public <V extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<V, R> writerFactory, CloudEventDataMapper<? extends CloudEventData> mapper) throws RuntimeException {
+    public <V extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<V, R> writerFactory,
+            CloudEventDataMapper<? extends CloudEventData> mapper) throws RuntimeException {
         CloudEventWriter<R> visitor = writerFactory.create(event.getSpecVersion());
         this.readAttributes(visitor);
         this.readExtensions(visitor);
@@ -43,16 +42,6 @@ public class CloudEventReaderAdapter implements CloudEventReader, CloudEventCont
         }
 
         return visitor.end();
-    }
-
-    @Override
-    public void readAttributes(CloudEventAttributesWriter writer) throws RuntimeException {
-        context.readAttributes(writer);
-    }
-
-    @Override
-    public void readExtensions(CloudEventExtensionsWriter writer) throws RuntimeException {
-        context.readExtensions(writer);
     }
 
 }

--- a/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
@@ -51,17 +51,7 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
     }
 
     public CloudEventBuilder(io.cloudevents.CloudEventContext context) {
-        super();
-        for (String name: context.getAttributeNames()) {
-            if (!name.equals(CloudEventV03.SPECVERSION)) {
-                Object value = context.getAttribute(name);
-                if (value instanceof String) {
-                    withAttribute(name, (String) value);
-                } else {
-                    withAttribute(name, value.toString());
-                }
-            }
-        }
+        super(context);
     }
 
     @Override

--- a/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
@@ -16,15 +16,16 @@
  */
 package io.cloudevents.core.v03;
 
-import io.cloudevents.SpecVersion;
-import io.cloudevents.core.CloudEventUtils;
-import io.cloudevents.core.impl.BaseCloudEventBuilder;
-import io.cloudevents.rw.CloudEventRWException;
-import io.cloudevents.types.Time;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.OffsetDateTime;
+
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.CloudEventUtils;
+import io.cloudevents.core.impl.BaseCloudEventBuilder;
+import io.cloudevents.rw.CloudEventContextReader;
+import io.cloudevents.rw.CloudEventRWException;
+import io.cloudevents.types.Time;
 
 /**
  * CloudEvent V0.3 builder.
@@ -55,12 +56,14 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
     }
 
     @Override
-    protected void setAttributes(io.cloudevents.CloudEvent event) {
+    protected void setAttributes(io.cloudevents.CloudEventContext event) {
+        CloudEventContextReader contextReader = CloudEventUtils.toContextReader(event);
         if (event.getSpecVersion() == SpecVersion.V03) {
-            CloudEventUtils.toContextReader(event).readAttributes(this);
+            contextReader.readAttributes(this);
         } else {
-            CloudEventUtils.toContextReader(event).readAttributes(new V1ToV03AttributesConverter(this));
+            contextReader.readAttributes(new V1ToV03AttributesConverter(this));
         }
+        contextReader.readExtensions(this);
     }
 
     public CloudEventBuilder withId(String id) {

--- a/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
@@ -50,6 +50,20 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
         super(event);
     }
 
+    public CloudEventBuilder(io.cloudevents.CloudEventContext context) {
+        super();
+        for (String name: context.getAttributeNames()) {
+            if (!name.equals(CloudEventV03.SPECVERSION)) {
+                Object value = context.getAttribute(name);
+                if (value instanceof String) {
+                    withAttribute(name, (String) value);
+                } else {
+                    withAttribute(name, value.toString());
+                }
+            }
+        }
+    }
+
     @Override
     protected void setAttributes(io.cloudevents.CloudEvent event) {
         if (event.getSpecVersion() == SpecVersion.V03) {

--- a/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
@@ -53,17 +53,7 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
     }
 
     public CloudEventBuilder(io.cloudevents.CloudEventContext context) {
-        super();
-        for (String name: context.getAttributeNames()) {
-            if (!name.equals(CloudEventV1.SPECVERSION)) {
-                Object value = context.getAttribute(name);
-                if (value instanceof String) {
-                    withAttribute(name, (String) value);
-                } else {
-                    withAttribute(name, value.toString());
-                }
-            }
-        }
+        super(context);
     }
 
     @Override

--- a/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
@@ -21,6 +21,7 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.CloudEventUtils;
 import io.cloudevents.core.impl.BaseCloudEventBuilder;
+import io.cloudevents.rw.CloudEventContextReader;
 import io.cloudevents.rw.CloudEventRWException;
 import io.cloudevents.types.Time;
 
@@ -57,12 +58,14 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
     }
 
     @Override
-    protected void setAttributes(io.cloudevents.CloudEvent event) {
+    protected void setAttributes(io.cloudevents.CloudEventContext event) {
+        CloudEventContextReader contextReader = CloudEventUtils.toContextReader(event);
         if (event.getSpecVersion() == SpecVersion.V1) {
-            CloudEventUtils.toContextReader(event).readAttributes(this);
+            contextReader.readAttributes(this);
         } else {
-            CloudEventUtils.toContextReader(event).readAttributes(new V03ToV1AttributesConverter(this));
+            contextReader.readAttributes(new V03ToV1AttributesConverter(this));
         }
+        contextReader.readExtensions(this);
     }
 
     public CloudEventBuilder withId(String id) {

--- a/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
@@ -52,6 +52,20 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
         super(event);
     }
 
+    public CloudEventBuilder(io.cloudevents.CloudEventContext context) {
+        super();
+        for (String name: context.getAttributeNames()) {
+            if (!name.equals(CloudEventV1.SPECVERSION)) {
+                Object value = context.getAttribute(name);
+                if (value instanceof String) {
+                    withAttribute(name, (String) value);
+                } else {
+                    withAttribute(name, value.toString());
+                }
+            }
+        }
+    }
+
     @Override
     protected void setAttributes(io.cloudevents.CloudEvent event) {
         if (event.getSpecVersion() == SpecVersion.V1) {

--- a/core/src/test/java/io/cloudevents/core/impl/BaseCloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/impl/BaseCloudEventBuilderTest.java
@@ -1,15 +1,15 @@
 package io.cloudevents.core.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.extensions.DistributedTracingExtension;
 import io.cloudevents.core.test.Data;
-import io.cloudevents.rw.CloudEventRWException;
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseCloudEventBuilderTest {
 

--- a/core/src/test/java/io/cloudevents/core/v03/CloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/v03/CloudEventBuilderTest.java
@@ -74,6 +74,24 @@ public class CloudEventBuilderTest {
     }
 
     @Test
+    void testCopyExtensions() {
+        io.cloudevents.core.v03.CloudEventBuilder templateBuilder = CloudEventBuilder.v03()
+            .withId(ID)
+            .withType(TYPE)
+            .withSource(SOURCE)
+            .withSubject(SUBJECT)
+            .withTime(TIME)
+            .withExtension("astring", "aaa")
+            .withExtension("aboolean", "true")
+            .withExtension("anumber", "10");
+
+        CloudEvent event = templateBuilder.build();
+        CloudEvent cloned = new io.cloudevents.core.v03.CloudEventBuilder(event).build();
+
+        assertThat(cloned).isEqualTo(event);
+    }
+
+    @Test
     void testNewBuilder() {
         io.cloudevents.core.v03.CloudEventBuilder templateBuilder = CloudEventBuilder.v03()
             .withId(ID)

--- a/core/src/test/java/io/cloudevents/core/v1/CloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/v1/CloudEventBuilderTest.java
@@ -75,6 +75,25 @@ public class CloudEventBuilderTest {
     }
 
     @Test
+    void testCopyExtensions() {
+        io.cloudevents.core.v1.CloudEventBuilder templateBuilder = CloudEventBuilder.v1()
+            .withId(ID)
+            .withType(TYPE)
+            .withSource(SOURCE)
+            .withData(DATACONTENTTYPE_JSON, DATASCHEMA, DATA_JSON_SERIALIZED)
+            .withSubject(SUBJECT)
+            .withTime(TIME)
+            .withExtension("astring", "aaa")
+            .withExtension("aboolean", "true")
+            .withExtension("anumber", "10");
+
+        CloudEvent event = templateBuilder.build();
+        CloudEvent cloned = new io.cloudevents.core.v1.CloudEventBuilder(event).build();
+
+        assertThat(cloned).isEqualTo(event);
+    }
+
+    @Test
     void testNewBuilder() {
         io.cloudevents.core.v1.CloudEventBuilder templateBuilder = CloudEventBuilder.v1()
             .withId(ID)


### PR DESCRIPTION
As discussed in #293 this change introduces a new interface
that extends CloudEventAttributes and CloudEventExtensions.
A builder would be nice, but it's a much bigger change.
Also the BaseBuilder method signatures use CloudEvent when
they could use CloudEventContext, but there's no way to fix
that without major disruption either.