### PR TITLE
Bump Vertx from 4.0.0.Beta1 to 4.0.0.CR2

### DIFF
--- a/http/vertx/pom.xml
+++ b/http/vertx/pom.xml
@@ -31,7 +31,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <vertx.version>4.0.0.Beta1</vertx.version>
+        <vertx.version>4.0.0.CR2</vertx.version>
         <module-name>io.cloudevents.http.vertx</module-name>
     </properties>
 


### PR DESCRIPTION
A new Vertx release is out, bumping version.