### PR TITLE
Simplify BaseCloudEventBuilder constructor

### DIFF
--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -50,16 +50,10 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
         setAttributes(context);
     }
 
-    @SuppressWarnings("unchecked")
     public BaseCloudEventBuilder(CloudEvent event) {
-        this.self = (SELF) this;
-
+        this();
         this.setAttributes(event);
         this.data = event.getData();
-        this.extensions = new HashMap<>();
-        for (String k : event.getExtensionNames()) {
-            this.extensions.put(k, event.getExtension(k));
-        }
     }
 
     protected abstract void setAttributes(CloudEventContext event);


### PR DESCRIPTION
The change in #296 could have simplified the constructor 
further. This change does that.