### PR TITLE
Alternative implementation of initial introduction of spring support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <module>http/vertx</module>
         <module>http/restful-ws</module>
         <module>kafka</module>
+        <module>spring</module>
     </modules>
 
     <properties>

--- a/spring/README.md
+++ b/spring/README.md
@@ -1,0 +1,12 @@
+## Spring Support
+
+### Introduction
+
+This module provides classes and interfaces that can be used by [Spring frameworks](https://spring.io/) and integrations to assist with Cloud Event processing. 
+
+Given that Spring defines [Message](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/messaging/Message.html) abstraction, 
+which perfectly maps to the structure defined by Cloud Events specification, one may say Cloud Events are already supported by any Spring framework that 
+relies on `Message`. So this modules provides several utilities and strategies to simplify working with Cloud Events in the context of Spring 
+frameworks and integrations (see individual component's javadocs for more details).
+
+Please see individual samples in `examples/spring` directory of this SDK for more details.

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018-Present The CloudEvents Authors
+  ~ <p>
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ <p>
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ <p>
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.cloudevents</groupId>
+        <artifactId>cloudevents-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cloudevents-spring</artifactId>
+    <name>CloudEvents - support for Spring</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <module-name>io.cloudevents.spring</module-name>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.4.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-messaging</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test deps -->
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <repositories>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/libs-snapshot-local</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/libs-milestone-local</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>spring-releases</id>
+            <name>Spring Releases</name>
+            <url>https://repo.spring.io/release</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+</project>
+

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <module-name>io.cloudevents.spring</module-name>
+        <spring-cloud-function.version>3.1.0-SNAPSHOT</spring-cloud-function.version>
     </properties>
 
     <dependencyManagement>
@@ -90,6 +91,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-function-webflux</artifactId>
+            <version>${spring-cloud-function.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring/src/main/java/io/cloudevents/spring/core/CloudEventHeaderUtils.java
+++ b/spring/src/main/java/io/cloudevents/spring/core/CloudEventHeaderUtils.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2020-Present The CloudEvents Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudevents.spring.core;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventAttributes;
+import io.cloudevents.CloudEventContext;
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.builder.CloudEventBuilder;
+
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Miscellaneous utility methods to assist with Cloud Event attributes. Primarily intended
+ * for the internal use within Spring-based frameworks or integrations.
+ *
+ * @author Oleg Zhurakousky
+ * @author Dave Syer
+ * @since 2.0
+ */
+public final class CloudEventHeaderUtils {
+
+	private CloudEventHeaderUtils() {
+	}
+
+	/**
+	 * String value of 'application/cloudevents' mime type.
+	 */
+	public static String APPLICATION_CLOUDEVENTS_VALUE = "application/cloudevents";
+
+	/**
+	 * {@link MimeType} instance representing 'application/cloudevents' mime type.
+	 */
+	public static MimeType APPLICATION_CLOUDEVENTS = MimeTypeUtils.parseMimeType(APPLICATION_CLOUDEVENTS_VALUE);
+
+	/**
+	 * Prefix for attributes.
+	 */
+	public static String DEFAULT_ATTR_PREFIX = "ce_";
+
+	/**
+	 * AMQP attributes prefix.
+	 */
+	public static String AMQP_ATTR_PREFIX = "cloudEvents:";
+
+	/**
+	 * Prefix for attributes.
+	 */
+	public static String HTTP_ATTR_PREFIX = "ce-";
+
+	/**
+	 * Value for 'data' attribute.
+	 */
+	public static String DATA = "data";
+
+	/**
+	 * Value for 'id' attribute.
+	 */
+	public static String ID = "id";
+
+	/**
+	 * Value for 'source' attribute.
+	 */
+	public static String SOURCE = "source";
+
+	/**
+	 * Value for 'specversion' attribute.
+	 */
+	public static String SPECVERSION = "specversion";
+
+	/**
+	 * Value for 'type' attribute.
+	 */
+	public static String TYPE = "type";
+
+	/**
+	 * Value for 'datacontenttype' attribute.
+	 */
+	public static String DATACONTENTTYPE = "datacontenttype";
+
+	/**
+	 * Value for 'dataschema' attribute.
+	 */
+	public static String DATASCHEMA = "dataschema";
+
+	/**
+	 * V03 name for 'dataschema' attribute.
+	 */
+	public static final String SCHEMAURL = "schemaurl";
+
+	/**
+	 * Value for 'subject' attribute.
+	 */
+	public static String SUBJECT = "subject";
+
+	/**
+	 * Value for 'time' attribute.
+	 */
+	public static String TIME = "time";
+
+	/**
+	 * Will wrap the provided map of headers as {@link MutableCloudEventHeaders}.
+	 * @param headers map representing headers
+	 * @return instance of {@link CloudEventAttributes}
+	 */
+	public static CloudEventBuilder fromMap(Map<String, Object> headers) {
+		MutableCloudEventHeaders reader = new MutableCloudEventHeaders(toCanonical(headers));
+		return reader.getBuilder();
+	}
+
+	/**
+	 * Will convert these attributes to {@link Map} of headers where each attribute will
+	 * be prefixed with the value of 'prefixToUse'.
+	 * @param prefixToUse prefix to be used on attributes
+	 * @return map of headers.
+	 */
+	public static Map<String, Object> toMap(CloudEventContext attributes, String prefixToUse) {
+		Map<String, Object> result = new HashMap<>();
+		if (!StringUtils.hasText(prefixToUse)) {
+			prefixToUse = "";
+		}
+		for (String key : attributes.getAttributeNames()) {
+			Object value = attributes.getAttribute(key);
+			if (value != null && !(value instanceof String)) {
+				value = value.toString();
+			}
+			if (value != null) {
+				result.put(prefixToUse + key, value);
+			}
+		}
+		for (String key : attributes.getExtensionNames()) {
+			Object value = attributes.getExtension(key);
+			if (value != null && !(value instanceof String)) {
+				value = value.toString();
+			}
+			if (value != null) {
+				result.put(prefixToUse + key, value);
+			}
+		}
+		result.put(prefixToUse + CloudEventHeaderUtils.SPECVERSION, attributes.getSpecVersion().toString());
+		return result;
+	}
+
+	private static String determinePrefixToUse(Map<String, Object> messageHeaders) {
+		Set<String> keys = messageHeaders.keySet();
+		if (keys.contains(CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX + CloudEventHeaderUtils.ID)) {
+			return CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX;
+		}
+		else if (keys.contains(CloudEventHeaderUtils.HTTP_ATTR_PREFIX + CloudEventHeaderUtils.ID)) {
+			return CloudEventHeaderUtils.HTTP_ATTR_PREFIX;
+		}
+		else if (keys.contains(CloudEventHeaderUtils.AMQP_ATTR_PREFIX + CloudEventHeaderUtils.ID)) {
+			return CloudEventHeaderUtils.AMQP_ATTR_PREFIX;
+		}
+		else if (keys.contains("user-agent")) {
+			return CloudEventHeaderUtils.HTTP_ATTR_PREFIX;
+		}
+		return "";
+	}
+
+	/**
+	 * Extract canonical version of map with CloudEvent keys.
+	 * @param headers a map of headers
+	 * @return a canonical form of the same map with {@link CloudEvent} attribute names
+	 */
+	public static Map<String, Object> toCanonical(Map<String, Object> headers) {
+		String prefix = determinePrefixToUse(headers);
+		SpecVersion specVersion = extractSpecVersion(headers, prefix);
+		Map<String, Object> result = new HashMap<>();
+		for (String name : headers.keySet()) {
+			if (name.startsWith(prefix) && name.length() > prefix.length()) {
+				result.put(name.substring(prefix.length()), headers.get(name));
+			}
+		}
+		result.put(CloudEventHeaderUtils.SPECVERSION, specVersion);
+		if (headers.containsKey(prefix + CloudEventHeaderUtils.DATA)) {
+			result.put(CloudEventHeaderUtils.DATA, headers.get(prefix + CloudEventHeaderUtils.DATA));
+		}
+		return result;
+	}
+
+	private static SpecVersion extractSpecVersion(Map<String, Object> headers, String prefix) {
+		String key = prefix + CloudEventHeaderUtils.SPECVERSION;
+		if (headers.containsKey(key)) {
+			Object object = headers.get(key);
+			if (object instanceof SpecVersion) {
+				return (SpecVersion) object;
+			}
+			if (object != null) {
+				return SpecVersion.parse(object.toString());
+			}
+		}
+		return SpecVersion.V1;
+	}
+
+	public static boolean isValidCloudEvent(Map<String, Object> attributes) {
+		return new MutableCloudEventHeaders(attributes).isValidCloudEvent();
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/core/CloudEventHeadersProvider.java
+++ b/spring/src/main/java/io/cloudevents/spring/core/CloudEventHeadersProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020-Present The CloudEvents Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudevents.spring.core;
+
+import io.cloudevents.CloudEventContext;
+
+/**
+ * Strategy that should be implemented by the user to help with outgoing Cloud Event
+ * headers. <br>
+ * <br>
+ * NOTE: The provided `attributes` may or may not be initialized with default values, so
+ * it is the responsibility of the user to ensure that all required Cloud Events
+ * attributes are set. That said, various Spring frameworks which utilize this interface
+ * will ensure that the 'provided' attributes are initialized with default values, leaving
+ * to responsible to only set the attributes you need. <br>
+ * Once implemented, simply configure it as a bean and the framework will invoke it before
+ * the outbound Cloud Event Message is finalized.
+ *
+ * <pre>
+ * &#64;Bean
+ * public CloudEventHeadersProvider cloudEventHeadersProvider() {
+ * 	return attributes -&gt;
+ *		CloudEventHeaderUtils.fromAttributes(attributes).withSource("https://interface21.com/").withType("com.interface21").build();
+ * }
+ * </pre>
+ *
+ * @author Oleg Zhurakousky
+ * @author Dave Syer
+ * @since 2.0
+ */
+@FunctionalInterface
+public interface CloudEventHeadersProvider {
+
+	/**
+	 * @param attributes instance of {@link CloudEventContext}
+	 * @return modified {@link CloudEventContext}
+	 */
+	CloudEventContext getOutputHeaders(CloudEventContext attributes);
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/core/MutableCloudEventHeaders.java
+++ b/spring/src/main/java/io/cloudevents/spring/core/MutableCloudEventHeaders.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.core;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.cloudevents.CloudEventAttributes;
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.builder.CloudEventBuilder;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Dave Syer
+ *
+ */
+class MutableCloudEventHeaders {
+
+	private Map<String, Object> map = new HashMap<>();
+
+	MutableCloudEventHeaders(Map<String, Object> headers) {
+		map.putAll(headers);
+		safeString(headers, CloudEventHeaderUtils.ID);
+		safeTime(headers, CloudEventHeaderUtils.TIME);
+		safeUri(headers, CloudEventHeaderUtils.SOURCE);
+		safeUri(headers, CloudEventHeaderUtils.DATASCHEMA);
+		safeUri(headers, CloudEventHeaderUtils.SCHEMAURL);
+		map.put(CloudEventHeaderUtils.SPECVERSION, getSpecVersion());
+	}
+
+	private void safeString(Map<String, Object> headers, String key) {
+		Object value = headers.get(key);
+		if (value != null && !(value instanceof String)) {
+			map.put(key, value.toString());
+		}
+	}
+
+	private void safeTime(Map<String, Object> headers, String key) {
+		Object value = headers.get(key);
+		if (value instanceof String) {
+			map.put(key, OffsetTime.parse((String) value));
+		}
+	}
+
+	private void safeUri(Map<String, Object> headers, String key) {
+		Object value = headers.get(key);
+		if (value instanceof String) {
+			map.put(key, URI.create((String) value));
+		}
+	}
+
+	private SpecVersion getSpecVersion() {
+		SpecVersion specVersion = (SpecVersion) this.getAttribute(CloudEventHeaderUtils.SPECVERSION);
+		return specVersion == null ? SpecVersion.V1 : specVersion;
+	}
+
+	// Visible for testing
+	Object getAttribute(String attributeName) {
+		return map.get(attributeName);
+	}
+
+	/**
+	 * Determines if this instance of {@link CloudEventAttributes} represents valid Cloud
+	 * Event. This implies that it contains all 4 required attributes (id, source, type
+	 * and specversion)
+	 * @return true if this instance represents a valid Cloud Event
+	 */
+	public boolean isValidCloudEvent() {
+		return StringUtils.hasText((String) getAttribute(CloudEventHeaderUtils.ID))
+				&& StringUtils.hasText((String) getAttribute(CloudEventHeaderUtils.SOURCE))
+				&& StringUtils.hasText((String) getAttribute(CloudEventHeaderUtils.TYPE));
+	}
+
+	private Set<String> getAttributeNames() {
+		return getSpecVersion().getAllAttributes().stream().filter(s -> getAttribute(s) != null)
+				.collect(Collectors.toSet());
+	}
+
+	public CloudEventBuilder getBuilder() {
+		CloudEventBuilder builder = CloudEventBuilder.fromSpecVersion(this.getSpecVersion());
+		Set<String> names = this.getAttributeNames();
+		for (String name : names) {
+			Object value = this.getAttribute(name);
+			if (value instanceof String) {
+				builder.withAttribute(name, (String) value);
+			}
+			else if (value instanceof URI) {
+				builder.withAttribute(name, (URI) value);
+			}
+			else if (value instanceof OffsetDateTime) {
+				builder.withAttribute(name, (OffsetDateTime) value);
+			}
+		}
+		for (String name : this.map.keySet()) {
+			if (names.contains(name)) {
+				continue;
+			}
+			Object value = this.map.get(name);
+			if (value instanceof String) {
+				builder.withExtension(name, (String) value);
+			}
+			else if (value instanceof Number) {
+				builder.withExtension(name, (Number) value);
+			}
+			else if (value instanceof Boolean) {
+				builder.withExtension(name, (Boolean) value);
+			}
+		}
+		return builder;
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/core/package-info.java
+++ b/spring/src/main/java/io/cloudevents/spring/core/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides classes related to working with Cloud Events within the context of Spring.
+ */
+package io.cloudevents.spring.core;

--- a/spring/src/main/java/io/cloudevents/spring/http/CloudEventHttpUtils.java
+++ b/spring/src/main/java/io/cloudevents/spring/http/CloudEventHttpUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.http;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import io.cloudevents.CloudEventContext;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.spring.core.CloudEventHeaderUtils;
+
+import org.springframework.http.HttpHeaders;
+
+/**
+ * Miscellaneous utility methods to assist with Cloud Events in the context of Spring Web
+ * frameworks. Primarily intended for the internal use within Spring-based frameworks or
+ * integrations.
+ *
+ * @author Dave Syer
+ * @since 2.0
+ */
+public class CloudEventHttpUtils {
+
+	public static HttpHeaders toHttp(CloudEventContext attributes) {
+		HttpHeaders headers = new HttpHeaders();
+		for (String key : attributes.getAttributeNames()) {
+			String target = CloudEventHeaderUtils.HTTP_ATTR_PREFIX + key;
+			if (attributes.getAttribute(key) != null) {
+				// TODO: need to convert timestamps?
+				headers.set(target, attributes.getAttribute(key).toString());
+			}
+		}
+		for (String key : attributes.getExtensionNames()) {
+			String target = CloudEventHeaderUtils.HTTP_ATTR_PREFIX + key;
+			if (attributes.getExtension(key) != null) {
+				// TODO: need to convert timestamps?
+				headers.set(target, attributes.getExtension(key).toString());
+			}
+		}
+		return headers;
+	}
+
+	public static CloudEventBuilder fromHttp(HttpHeaders headers) {
+		Map<String, Object> map = new HashMap<>();
+		map.putAll(headers.toSingleValueMap());
+		return CloudEventHeaderUtils.fromMap(map).withId(UUID.randomUUID().toString());
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/http/package-info.java
+++ b/spring/src/main/java/io/cloudevents/spring/http/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides classes related to working with Cloud Events within the context of Spring MVC.
+ */
+package io.cloudevents.spring.http;

--- a/spring/src/main/java/io/cloudevents/spring/messaging/CloudEventMessageConverter.java
+++ b/spring/src/main/java/io/cloudevents/spring/messaging/CloudEventMessageConverter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.messaging;
+
+import java.nio.charset.Charset;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventContext;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.spring.core.CloudEventHeaderUtils;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * A {@link MessageConverter} that can translate to and from a {@link Message
+ * Message&lt;byte[]>} and a {@link CloudEvent}. The {@link CloudEventContext} is
+ * canonicalized, with key names given a "ce_" prefix in the {@link MessageHeaders}.
+ * 
+ * @author Dave Syer
+ *
+ */
+public class CloudEventMessageConverter implements MessageConverter {
+
+	@Override
+	public Object fromMessage(Message<?> message, Class<?> targetClass) {
+		byte[] payload = getBinaryData(message);
+		if (CloudEvent.class.isAssignableFrom(targetClass)) {
+			CloudEventBuilder builder = CloudEventHeaderUtils.fromMap(message.getHeaders());
+			if (payload != null) {
+				return builder.withData(payload).build();
+			}
+			return builder.build();
+		}
+		return null;
+	}
+
+	private byte[] getBinaryData(Message<?> message) {
+		Object payload = message.getPayload();
+		if (payload instanceof byte[]) {
+			return (byte[]) payload;
+		}
+		else if (payload instanceof String) {
+			return ((String) payload).getBytes(Charset.defaultCharset());
+		}
+		return null;
+	}
+
+	@Override
+	public Message<?> toMessage(Object payload, MessageHeaders headers) {
+		if (payload instanceof CloudEvent) {
+			CloudEvent event = (CloudEvent) payload;
+			CloudEventData data = event.getData();
+			byte[] bytes = data == null ? new byte[0] : data.toBytes();
+			return MessageBuilder.withPayload(bytes).copyHeaders(headers)
+					.copyHeaders(CloudEventHeaderUtils.toMap(event, CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX)).build();
+		}
+		return null;
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/messaging/CloudEventMessageUtils.java
+++ b/spring/src/main/java/io/cloudevents/spring/messaging/CloudEventMessageUtils.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020-Present The CloudEvents Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudevents.spring.messaging;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.spring.core.CloudEventHeaderUtils;
+import io.cloudevents.spring.core.CloudEventHeadersProvider;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.ContentTypeResolver;
+import org.springframework.messaging.converter.DefaultContentTypeResolver;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Miscellaneous utility methods to assist with representing Cloud Event as Spring
+ * {@link Message} <br>
+ * Primarily intended for the internal use within Spring-based frameworks and
+ * integrations;
+ *
+ * @author Oleg Zhurakousky
+ * @author Dave Syer
+ * @since 2.0
+ */
+public final class CloudEventMessageUtils {
+
+	private static final ContentTypeResolver contentTypeResolver = new DefaultContentTypeResolver();
+
+	private CloudEventMessageUtils() {
+
+	}
+
+	@SuppressWarnings("unchecked")
+	public static Message<?> toBinary(Message<?> inputMessage, MessageConverter messageConverter) {
+		Map<String, Object> headers = inputMessage.getHeaders();
+		Map<String, Object> attributes = CloudEventHeaderUtils.toCanonical(headers);
+		String inputContentType = (String) attributes.get(CloudEventHeaderUtils.DATACONTENTTYPE);
+		// first check the obvious and see if content-type is `cloudevents`
+		if (!CloudEventHeaderUtils.isValidCloudEvent(attributes) && headers.containsKey(MessageHeaders.CONTENT_TYPE)) {
+			MimeType contentType = contentTypeResolver.resolve(inputMessage.getHeaders());
+			if (contentType.getType().equals(CloudEventHeaderUtils.APPLICATION_CLOUDEVENTS.getType()) && contentType
+					.getSubtype().startsWith(CloudEventHeaderUtils.APPLICATION_CLOUDEVENTS.getSubtype())) {
+
+				String dataContentType = StringUtils.hasText(inputContentType) ? inputContentType
+						: MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+				String suffix = contentType.getSubtypeSuffix();
+				MimeType cloudEventDeserializationContentType = MimeTypeUtils
+						.parseMimeType(contentType.getType() + "/" + suffix);
+				Message<?> cloudEventMessage = MessageBuilder.fromMessage(inputMessage)
+						.setHeader(MessageHeaders.CONTENT_TYPE, cloudEventDeserializationContentType)
+						.setHeader(CloudEventHeaderUtils.DATACONTENTTYPE, dataContentType).build();
+				Map<String, Object> structuredCloudEvent = (Map<String, Object>) messageConverter
+						.fromMessage(cloudEventMessage, Map.class);
+				Message<?> binaryCeMessage = buildBinaryMessageFromStructuredMap(structuredCloudEvent,
+						inputMessage.getHeaders());
+				return binaryCeMessage;
+			}
+		}
+		else if (StringUtils.hasText(inputContentType)) {
+			return MessageBuilder.fromMessage(inputMessage).setHeader(MessageHeaders.CONTENT_TYPE, inputContentType)
+					.build();
+		}
+		return inputMessage;
+	}
+
+	/**
+	 * Utility method to assist with creating output attributes. <br>
+	 * Typically user by {@link Consumer}. Unlike {@link Function} where framework(s)
+	 * internally do that once the function is executed and output is produced, Consumer
+	 * does not produce any output, so from the framework perspective it is the end of the
+	 * line. However, such Consumer may want to send new Cloud Event (e.g., via HTTP or
+	 * some messaging template) and thus still requires generation of output attributes.
+	 * @param message instance of input {@link Message}.
+	 * @param provider instance of CloudEventAttributesProvider.
+	 * @return an instance of {@link CloudEvent} as {@link CloudEventBuilder}
+	 */
+	public static CloudEventBuilder getOutputAttributes(Message<?> message, CloudEventHeadersProvider provider) {
+		CloudEventBuilder attributes = CloudEventHeaderUtils.fromMap(message.getHeaders())
+				.withId(message.getHeaders().getId().toString())
+				.withType(message.getPayload().getClass().getName().getClass().getName());
+		return CloudEventBuilder.fromContext(provider.getOutputHeaders(attributes.build()));
+	}
+
+	private static Message<?> buildBinaryMessageFromStructuredMap(Map<String, Object> structuredCloudEvent,
+			MessageHeaders originalHeaders) {
+		Map<String, Object> map = CloudEventHeaderUtils.toCanonical(structuredCloudEvent);
+		Object payload = map.get(CloudEventHeaderUtils.DATA);
+		if (payload == null) {
+			payload = Collections.emptyMap();
+		}
+		CloudEvent attributes = CloudEventHeaderUtils.fromMap(map).build();
+		return MessageBuilder.withPayload(payload)
+				.copyHeaders(CloudEventHeaderUtils.toMap(attributes, CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX))
+				.copyHeaders(originalHeaders)
+				.setHeader(CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX + CloudEventHeaderUtils.ID, attributes.getId())
+				.build();
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/messaging/package-info.java
+++ b/spring/src/main/java/io/cloudevents/spring/messaging/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides classes related to working with Cloud Events within the context of Spring Messaging.
+ */
+package io.cloudevents.spring.messaging;

--- a/spring/src/main/java/io/cloudevents/spring/mvc/CloudEventHttpMessageConverter.java
+++ b/spring/src/main/java/io/cloudevents/spring/mvc/CloudEventHttpMessageConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.mvc;
+
+import java.io.IOException;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.spring.http.CloudEventHttpUtils;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.util.StreamUtils;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class CloudEventHttpMessageConverter extends AbstractHttpMessageConverter<CloudEvent> {
+
+	public CloudEventHttpMessageConverter() {
+		super(MediaType.APPLICATION_OCTET_STREAM, MediaType.ALL);
+	}
+
+	@Override
+	protected boolean supports(Class<?> clazz) {
+		return CloudEvent.class.isAssignableFrom(clazz);
+	}
+
+	@Override
+	protected CloudEvent readInternal(Class<? extends CloudEvent> clazz, HttpInputMessage inputMessage)
+			throws IOException, HttpMessageNotReadableException {
+		return CloudEventHttpUtils.fromHttp(inputMessage.getHeaders())
+				.withData(StreamUtils.copyToByteArray(inputMessage.getBody())).build();
+	}
+
+	@Override
+	protected void writeInternal(CloudEvent event, HttpOutputMessage outputMessage)
+			throws IOException, HttpMessageNotWritableException {
+		outputMessage.getHeaders().addAll(CloudEventHttpUtils.toHttp(event));
+		StreamUtils.copy(event.getData().toBytes(), outputMessage.getBody());
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/webflux/CloudEventHttpMessageReader.java
+++ b/spring/src/main/java/io/cloudevents/spring/webflux/CloudEventHttpMessageReader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.webflux;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.spring.http.CloudEventHttpUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpInputMessage;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.util.StreamUtils;
+
+public class CloudEventHttpMessageReader implements HttpMessageReader<CloudEvent> {
+
+	@Override
+	public List<MediaType> getReadableMediaTypes() {
+		return Arrays.asList(MediaType.APPLICATION_OCTET_STREAM, MediaType.ALL);
+	}
+
+	@Override
+	public boolean canRead(ResolvableType elementType, MediaType mediaType) {
+		return CloudEvent.class.isAssignableFrom(elementType.toClass());
+	}
+
+	@Override
+	public Flux<CloudEvent> read(ResolvableType elementType, ReactiveHttpInputMessage message,
+			Map<String, Object> hints) {
+		return Flux.from(readMono(elementType, message, hints));
+	}
+
+	@Override
+	public Mono<CloudEvent> readMono(ResolvableType elementType, ReactiveHttpInputMessage message,
+			Map<String, Object> hints) {
+		HttpHeaders headers = message.getHeaders();
+		return DataBufferUtils.join(message.getBody()).map(body -> {
+			try {
+				return CloudEventHttpUtils.fromHttp(headers)
+						.withData(StreamUtils.copyToByteArray(body.asInputStream(true))).build();
+			}
+			catch (Exception e) {
+				throw new IllegalArgumentException(e);
+			}
+		});
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/webflux/CloudEventHttpMessageWriter.java
+++ b/spring/src/main/java/io/cloudevents/spring/webflux/CloudEventHttpMessageWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.webflux;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.spring.http.CloudEventHttpUtils;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpOutputMessage;
+import org.springframework.http.codec.HttpMessageWriter;
+
+public class CloudEventHttpMessageWriter implements HttpMessageWriter<CloudEvent> {
+
+	@Override
+	public List<MediaType> getWritableMediaTypes() {
+		return Arrays.asList(MediaType.APPLICATION_OCTET_STREAM, MediaType.ALL);
+	}
+
+	@Override
+	public boolean canWrite(ResolvableType elementType, MediaType mediaType) {
+		return CloudEvent.class.isAssignableFrom(elementType.toClass());
+	}
+
+	@Override
+	public Mono<Void> write(Publisher<? extends CloudEvent> inputStream, ResolvableType elementType,
+			MediaType mediaType, ReactiveHttpOutputMessage message, Map<String, Object> hints) {
+		return Mono.from(inputStream).flatMap(event -> {
+			message.getHeaders().addAll(CloudEventHttpUtils.toHttp(event));
+			byte[] bytes = event.getData().toBytes();
+			DataBuffer data = message.bufferFactory().wrap(bytes);
+			message.getHeaders().setContentLength(bytes.length);
+			return message.writeWith(Mono.just(data));
+		});
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/webflux/CloudEventHttpMessageWriter.java
+++ b/spring/src/main/java/io/cloudevents/spring/webflux/CloudEventHttpMessageWriter.java
@@ -46,7 +46,7 @@ public class CloudEventHttpMessageWriter implements HttpMessageWriter<CloudEvent
 	public Mono<Void> write(Publisher<? extends CloudEvent> inputStream, ResolvableType elementType,
 			MediaType mediaType, ReactiveHttpOutputMessage message, Map<String, Object> hints) {
 		return Mono.from(inputStream).flatMap(event -> {
-			message.getHeaders().addAll(CloudEventHttpUtils.toHttp(event));
+			message.getHeaders().putAll(CloudEventHttpUtils.toHttp(event));
 			byte[] bytes = event.getData().toBytes();
 			DataBuffer data = message.bufferFactory().wrap(bytes);
 			message.getHeaders().setContentLength(bytes.length);

--- a/spring/src/test/java/io/cloudevents/spring/core/CloudEventHeaderUtilsTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/core/CloudEventHeaderUtilsTests.java
@@ -1,0 +1,99 @@
+package io.cloudevents.spring.core;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class CloudEventHeaderUtilsTests {
+
+	@Test
+	public void testWithEmpty() {
+		Map<String, Object> headers = new HashMap<>();
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
+			CloudEvent attributes = CloudEventHeaderUtils.fromMap(headers).build();
+			assertThat(attributes.getSpecVersion()).isEqualTo(SpecVersion.V1);
+			assertThat(attributes.getId()).isNull();
+			assertThat(attributes.getSource()).isNull();
+			assertThat(attributes.getType()).isNull();
+		});
+	}
+
+	@Test
+	public void testWithPrefix() {
+		Map<String, Object> headers = new HashMap<>();
+		headers.put("ce-scpecversion", "1.0");
+		headers.put("ce-id", "A234-1234-1234");
+		headers.put("ce-source", "https://spring.io/");
+		headers.put("ce-type", "org.springframework");
+		headers.put("ce-datacontenttype", "application/json");
+		CloudEvent attributes = CloudEventHeaderUtils.fromMap(headers).build();
+		assertThat(attributes.getSpecVersion()).isEqualTo(SpecVersion.V1);
+		assertThat(attributes.getId()).isEqualTo("A234-1234-1234");
+		assertThat(attributes.getSource()).isEqualTo(URI.create("https://spring.io/"));
+		assertThat(attributes.getType()).isEqualTo("org.springframework");
+		assertThat(attributes.getDataContentType()).isEqualTo("application/json");
+	}
+
+	@Test
+	public void testExtensionsWithPrefix() {
+		Map<String, Object> headers = new HashMap<>();
+		headers.put("ce-scpecversion", "1.0");
+		headers.put("ce-id", "A234-1234-1234");
+		headers.put("ce-source", "https://spring.io/");
+		headers.put("ce-type", "org.springframework");
+		headers.put("ce-foo", "bar");
+		CloudEvent attributes = CloudEventHeaderUtils.fromMap(headers).build();
+		assertThat(attributes.getSpecVersion()).isEqualTo(SpecVersion.V1);
+		assertThat(attributes.getId()).isEqualTo("A234-1234-1234");
+		assertThat(attributes.getSource()).isEqualTo(URI.create("https://spring.io/"));
+		assertThat(attributes.getType()).isEqualTo("org.springframework");
+		assertThat(attributes.getExtension("foo")).isEqualTo("bar");
+	}
+
+	@Test
+	public void testWithNoPrefix() {
+		Map<String, Object> headers = new HashMap<>();
+		headers.put("id", "A234-1234-1234");
+		headers.put("source", "https://spring.io/");
+		headers.put("type", "org.springframework");
+		headers.put("datacontenttype", "application/json");
+		CloudEvent attributes = CloudEventHeaderUtils.fromMap(headers).build();
+		assertThat(attributes.getId()).isEqualTo("A234-1234-1234");
+		assertThat(attributes.getSpecVersion()).isEqualTo(SpecVersion.V1);
+		assertThat(attributes.getSource()).isEqualTo(URI.create("https://spring.io/"));
+		assertThat(attributes.getType()).isEqualTo("org.springframework");
+		assertThat(attributes.getDataContentType()).isEqualTo("application/json");
+	}
+
+	@Test
+	public void testToHeadersNoPrefix() {
+		CloudEvent attributes = CloudEventBuilder.v1().withId("A234-1234-1234")
+				.withSource(URI.create("https://spring.io/")).withType("org.springframework").build();
+		Map<String, Object> headers = CloudEventHeaderUtils.toMap(attributes, null);
+		assertThat(headers.get("id")).isEqualTo("A234-1234-1234");
+		assertThat(headers.get("specversion")).isEqualTo("1.0");
+		assertThat(headers.get("source")).isEqualTo("https://spring.io/");
+		assertThat(headers.get("type")).isEqualTo("org.springframework");
+	}
+
+	@Test
+	public void testToHeaders() {
+		CloudEvent attributes = CloudEventBuilder.v1().withId("A234-1234-1234")
+				.withSource(URI.create("https://spring.io/")).withType("org.springframework").build();
+		Map<String, Object> headers = CloudEventHeaderUtils.toMap(attributes, "ce-");
+		assertThat(headers.get("ce-id")).isEqualTo("A234-1234-1234");
+		assertThat(headers).doesNotContainKey("id");
+		assertThat(headers.get("ce-specversion")).isEqualTo("1.0");
+		assertThat(headers.get("ce-source")).isEqualTo("https://spring.io/");
+		assertThat(headers.get("ce-type")).isEqualTo("org.springframework");
+	}
+
+}

--- a/spring/src/test/java/io/cloudevents/spring/core/MutableCloudEventHeadersTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/core/MutableCloudEventHeadersTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.core;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class MutableCloudEventHeadersTests {
+
+	@Test
+	void testEmpty() throws Exception {
+		MutableCloudEventHeaders attributes = new MutableCloudEventHeaders(Collections.emptyMap());
+		assertThat(attributes.getAttribute(CloudEventHeaderUtils.SPECVERSION)).isEqualTo(SpecVersion.V1);
+		assertThat(attributes.getAttribute(CloudEventHeaderUtils.ID)).isNull();
+	}
+
+	@Test
+	void testSetAttribute() throws Exception {
+		CloudEventBuilder builder = new MutableCloudEventHeaders(Collections.emptyMap()).getBuilder();
+		builder.withAttribute(CloudEventHeaderUtils.ID, "A1234-1234");
+		builder.withSource(URI.create("https://spring.io/"));
+		builder.withType("org.springframework");
+		CloudEvent attributes = builder.build();
+		assertThat(attributes.getSpecVersion()).isEqualTo(SpecVersion.V1);
+		assertThat(attributes.getId()).isEqualTo("A1234-1234");
+	}
+
+	@Test
+	void testV03() throws Exception {
+		CloudEventBuilder builder = new MutableCloudEventHeaders(
+				Collections.singletonMap(CloudEventHeaderUtils.SPECVERSION, SpecVersion.V03)).getBuilder();
+		builder.withAttribute(CloudEventHeaderUtils.ID, "A1234-1234");
+		builder.withAttribute(CloudEventHeaderUtils.SCHEMAURL, "https://schema.spring.io/ce-0.3");
+		builder.withSource(URI.create("https://spring.io/"));
+		builder.withType("org.springframework");
+		CloudEvent attributes = builder.build();
+		assertThat(attributes.getSpecVersion()).isEqualTo(SpecVersion.V03);
+		assertThat(attributes.getId()).isEqualTo("A1234-1234");
+		assertThat(attributes.getDataSchema().toString()).isEqualTo("https://schema.spring.io/ce-0.3");
+	}
+
+	@Test
+	void testV03MapWithExplicitSchema() throws Exception {
+		CloudEventBuilder attributes = new MutableCloudEventHeaders(
+				Collections.singletonMap(CloudEventHeaderUtils.SPECVERSION, SpecVersion.V03)).getBuilder();
+		attributes.withId("A1234-1234");
+		attributes.withSource(URI.create("https://spring.io/"));
+		attributes.withType("org.springframework");
+		attributes.withDataSchema(URI.create("https://schema.spring.io/ce-0.3"));
+		Map<String, Object> headers = CloudEventHeaderUtils.toMap(attributes.build(), "ce-");
+		assertThat(headers.get("ce-specversion")).isEqualTo("0.3");
+		assertThat(headers.get("ce-source")).isEqualTo("https://spring.io/");
+		assertThat(headers.get("ce-type")).isEqualTo("org.springframework");
+		assertThat(headers.get("ce-schemaurl")).isEqualTo("https://schema.spring.io/ce-0.3");
+	}
+
+	@Test
+	void testV03MapWithAttributeSchema() throws Exception {
+		CloudEventBuilder attributes = new MutableCloudEventHeaders(
+				Collections.singletonMap(CloudEventHeaderUtils.SPECVERSION, SpecVersion.V03)).getBuilder();
+		attributes.withId("A1234-1234");
+		attributes.withSource(URI.create("https://spring.io/"));
+		attributes.withType("org.springframework");
+		attributes.withAttribute(CloudEventHeaderUtils.SCHEMAURL, "https://schema.spring.io/ce-0.3");
+		Map<String, Object> headers = CloudEventHeaderUtils.toMap(attributes.build(), "ce-");
+		assertThat(headers.get("ce-specversion")).isEqualTo("0.3");
+		assertThat(headers.get("ce-source")).isEqualTo("https://spring.io/");
+		assertThat(headers.get("ce-type")).isEqualTo("org.springframework");
+		assertThat(headers.get("ce-schemaurl")).isEqualTo("https://schema.spring.io/ce-0.3");
+	}
+
+}

--- a/spring/src/test/java/io/cloudevents/spring/http/CloudEventHttpUtilsTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/http/CloudEventHttpUtilsTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.http;
+
+import java.net.URI;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventContext;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+class CloudEventHttpUtilsTests {
+
+	@Test
+	void extractHeaders() {
+		CloudEvent attributes = CloudEventBuilder.v1().withId("A234-1234-1234")
+				.withSource(URI.create("https://spring.io/")).withType("org.springframework").build();
+		HttpHeaders headers = CloudEventHttpUtils.toHttp(attributes);
+		assertThat(headers.getFirst("ce-id")).isEqualTo("A234-1234-1234");
+		assertThat(headers.getFirst("ce-specversion")).isEqualTo("1.0");
+		assertThat(headers.getFirst("ce-source")).isEqualTo("https://spring.io/");
+		assertThat(headers.getFirst("ce-type")).isEqualTo("org.springframework");
+	}
+
+	@Test
+	void extractHeadersWithExtensions() {
+		CloudEvent attributes = CloudEventBuilder.v1().withId("A234-1234-1234")
+				.withSource(URI.create("https://spring.io/")).withType("org.springframework")
+				.withExtension("foo", "bar").build();
+		HttpHeaders headers = CloudEventHttpUtils.toHttp(attributes);
+		assertThat(headers.getFirst("ce-id")).isEqualTo("A234-1234-1234");
+		assertThat(headers.getFirst("ce-foo")).isEqualTo("bar");
+	}
+
+	@Test
+	void roundTripWithExtensions() {
+		CloudEvent attributes = CloudEventBuilder.v1().withId("A234-1234-1234")
+				.withSource(URI.create("https://spring.io/")).withType("org.springframework")
+				.withExtension("foo", "bar").build();
+		HttpHeaders headers = CloudEventHttpUtils.toHttp(attributes);
+		CloudEventContext output = CloudEventHttpUtils.fromHttp(headers).build();
+		// ID is changed on output
+		assertThat(output.getId()).isNotNull();
+		assertThat(output.getId()).isNotEqualTo("A234-1234-1234");
+		assertThat(output.getExtension("foo")).isEqualTo("bar");
+	}
+
+}

--- a/spring/src/test/java/io/cloudevents/spring/messaging/CloudEventMessageUtilsTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/messaging/CloudEventMessageUtilsTests.java
@@ -1,0 +1,161 @@
+package io.cloudevents.spring.messaging;
+
+import java.net.URI;
+import java.util.Map;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.v1.CloudEventBuilder;
+import io.cloudevents.spring.core.CloudEventHeaderUtils;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CloudEventMessageUtilsTests {
+
+	String payloadWithHttpPrefix = "{\n" + "    \"ce-specversion\" : \"1.0\",\n"
+			+ "    \"ce-type\" : \"org.springframework\",\n" + "    \"ce-source\" : \"https://spring.io/\",\n"
+			+ "    \"ce-id\" : \"A234-1234-1234\",\n" + "    \"ce-datacontenttype\" : \"application/json\",\n"
+			+ "    \"ce-data\" : {\n" + "        \"version\" : \"1.0\",\n"
+			+ "        \"releaseName\" : \"Spring Framework\",\n" + "        \"releaseDate\" : \"24-03-2004\"\n"
+			+ "    }\n" + "}";
+
+	String payloadNoPrefix = "{\n" + "    \"specversion\" : \"1.0\",\n" + "    \"type\" : \"org.springframework\",\n"
+			+ "    \"source\" : \"https://spring.io/\",\n" + "    \"id\" : \"A234-1234-1234\",\n"
+			+ "    \"datacontenttype\" : \"application/json\",\n" + "    \"data\" : {\n"
+			+ "        \"version\" : \"1.0\",\n" + "        \"releaseName\" : \"Spring Framework\",\n"
+			+ "        \"releaseDate\" : \"24-03-2004\"\n" + "    }\n" + "}";
+
+	String payloadNoDataContentType = "{\n" + "    \"ce_specversion\" : \"1.0\",\n"
+			+ "    \"ce_type\" : \"org.springframework\",\n" + "    \"ce_source\" : \"https://spring.io/\",\n"
+			+ "    \"ce_id\" : \"A234-1234-1234\",\n" + "    \"ce_datacontenttype\" : \"application/json\",\n"
+			+ "    \"data\" : {\n" + "        \"version\" : \"1.0\",\n"
+			+ "        \"releaseName\" : \"Spring Framework\",\n" + "        \"releaseDate\" : \"24-03-2004\"\n"
+			+ "    }\n" + "}";
+
+	@Test
+	public void testGenerateAttributes() {
+		Message<String> message = MessageBuilder.withPayload("Hello")
+				.copyHeaders(CloudEventHeaderUtils.toMap(new CloudEventBuilder().withId("A234-1234-1234")
+						.withSource(URI.create("https://spring.io/")).withType("org.springframework").build(), "ce_"))
+				.build();
+		CloudEvent attributes = CloudEventMessageUtils.getOutputAttributes(message, attrs -> attrs).build();
+		assertThat(attributes.getId()).isNotEqualTo("A234-1234-1234");
+		assertThat(attributes.getSource()).isEqualTo(URI.create("https://spring.io/"));
+		assertThat(attributes.getType()).isEqualTo(String.class.getName());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testStructuredToBinaryWithPrefix() {
+		Message<String> structuredMessage = MessageBuilder.withPayload(payloadWithHttpPrefix)
+				.setHeader(MessageHeaders.CONTENT_TYPE,
+						CloudEventHeaderUtils.APPLICATION_CLOUDEVENTS_VALUE + "+json")
+				.setHeader("foo", "bar").build();
+
+		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+		Message<Map<String, Object>> binaryMessage = (Message<Map<String, Object>>) CloudEventMessageUtils
+				.toBinary(structuredMessage, converter);
+		CloudEvent attributes = CloudEventHeaderUtils.fromMap(binaryMessage.getHeaders()).build();
+		assertThat(attributes.getId()).isEqualTo("A234-1234-1234");
+		assertThat(attributes.getSource()).isEqualTo(URI.create("https://spring.io/"));
+		assertThat(attributes.getType()).isEqualTo("org.springframework");
+		assertThat(attributes.getDataContentType()).isEqualTo("application/json");
+		assertThat(binaryMessage.getHeaders().get("foo")).isEqualTo("bar");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testStructuredToBinaryWithPrefixAndUserAgent() {
+		Message<String> structuredMessage = MessageBuilder.withPayload(payloadWithHttpPrefix)
+				.setHeader(MessageHeaders.CONTENT_TYPE,
+						CloudEventHeaderUtils.APPLICATION_CLOUDEVENTS_VALUE + "+json")
+				.setHeader("user-agent", "oleg").build();
+
+		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+		Message<Map<String, Object>> binaryMessage = (Message<Map<String, Object>>) CloudEventMessageUtils
+				.toBinary(structuredMessage, converter);
+		CloudEvent attributes = CloudEventHeaderUtils.fromMap(binaryMessage.getHeaders()).build();
+		assertThat(attributes.getId()).isEqualTo("A234-1234-1234");
+		assertThat(attributes.getSource()).isEqualTo(URI.create("https://spring.io/"));
+		assertThat(attributes.getType()).isEqualTo("org.springframework");
+		assertThat(attributes.getDataContentType()).isEqualTo("application/json");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testStructuredToBinaryNoPrefix() {
+		Message<String> structuredMessage = MessageBuilder.withPayload(payloadNoPrefix).setHeader(
+				MessageHeaders.CONTENT_TYPE, CloudEventHeaderUtils.APPLICATION_CLOUDEVENTS_VALUE + "+json").build();
+
+		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+		Message<Map<String, Object>> binaryMessage = (Message<Map<String, Object>>) CloudEventMessageUtils
+				.toBinary(structuredMessage, converter);
+		CloudEvent attributes = CloudEventHeaderUtils.fromMap(binaryMessage.getHeaders()).build();
+		assertThat(attributes.getId()).isEqualTo("A234-1234-1234");
+		assertThat(attributes.getSource()).isEqualTo(URI.create("https://spring.io/"));
+		assertThat(attributes.getType()).isEqualTo("org.springframework");
+		assertThat(attributes.getDataContentType()).isEqualTo("application/json");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testStructuredToBinaryNoDataContentType() {
+		Message<String> structuredMessage = MessageBuilder.withPayload(payloadNoPrefix).setHeader(
+				MessageHeaders.CONTENT_TYPE, CloudEventHeaderUtils.APPLICATION_CLOUDEVENTS_VALUE + "+json").build();
+
+		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+		Message<Map<String, Object>> binaryMessage = (Message<Map<String, Object>>) CloudEventMessageUtils
+				.toBinary(structuredMessage, converter);
+		CloudEvent attributes = CloudEventHeaderUtils.fromMap(binaryMessage.getHeaders()).build();
+		assertThat(attributes.getId()).isEqualTo("A234-1234-1234");
+		assertThat(attributes.getSource()).isEqualTo(URI.create("https://spring.io/"));
+		assertThat(attributes.getType()).isEqualTo("org.springframework");
+		assertThat(attributes.getDataContentType()).isEqualTo("application/json");
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void testStructuredToBinaryBackToMessageHeaders() {
+		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+		Message<String> structuredMessage = MessageBuilder.withPayload(payloadWithHttpPrefix).setHeader(
+				MessageHeaders.CONTENT_TYPE, CloudEventHeaderUtils.APPLICATION_CLOUDEVENTS_VALUE + "+json").build();
+
+		Message<Map<String, Object>> binaryMessage = (Message<Map<String, Object>>) CloudEventMessageUtils
+				.toBinary(structuredMessage, converter);
+		assertThat(binaryMessage.getHeaders().containsKey("ce-data")).isFalse();
+		CloudEvent attributes = CloudEventHeaderUtils.fromMap(binaryMessage.getHeaders()).build();
+
+		Map headers = CloudEventHeaderUtils.toMap(attributes, CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX);
+		assertThat(headers.get(CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX + CloudEventHeaderUtils.ID))
+				.isEqualTo("A234-1234-1234");
+		assertThat(headers.get(CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX + CloudEventHeaderUtils.SOURCE))
+				.isEqualTo("https://spring.io/");
+		assertThat(headers.get(CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX + CloudEventHeaderUtils.TYPE))
+				.isEqualTo("org.springframework");
+		assertThat(headers.get(CloudEventHeaderUtils.DEFAULT_ATTR_PREFIX + CloudEventHeaderUtils.DATACONTENTTYPE))
+				.isEqualTo("application/json");
+
+		structuredMessage = MessageBuilder.withPayload(payloadNoPrefix).setHeader(MessageHeaders.CONTENT_TYPE,
+				CloudEventHeaderUtils.APPLICATION_CLOUDEVENTS_VALUE + "+json").build();
+
+		binaryMessage = (Message<Map<String, Object>>) CloudEventMessageUtils.toBinary(structuredMessage, converter);
+		assertThat(binaryMessage.getHeaders().containsKey("data")).isFalse();
+		attributes = CloudEventHeaderUtils.fromMap(binaryMessage.getHeaders()).build();
+
+		headers = CloudEventHeaderUtils.toMap(attributes, CloudEventHeaderUtils.HTTP_ATTR_PREFIX);
+		assertThat(headers.get(CloudEventHeaderUtils.HTTP_ATTR_PREFIX + CloudEventHeaderUtils.ID))
+				.isEqualTo("A234-1234-1234");
+		assertThat(headers.get(CloudEventHeaderUtils.HTTP_ATTR_PREFIX + CloudEventHeaderUtils.SOURCE))
+				.isEqualTo("https://spring.io/");
+		assertThat(headers.get(CloudEventHeaderUtils.HTTP_ATTR_PREFIX + CloudEventHeaderUtils.TYPE))
+				.isEqualTo("org.springframework");
+		assertThat(headers.get(CloudEventHeaderUtils.HTTP_ATTR_PREFIX + CloudEventHeaderUtils.DATACONTENTTYPE))
+				.isEqualTo("application/json");
+	}
+
+}

--- a/spring/src/test/java/io/cloudevents/spring/messaging/CloudFunctionTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/messaging/CloudFunctionTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.messaging;
+
+import java.net.URI;
+import java.util.UUID;
+import java.util.function.Function;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.spring.webflux.CloudEventHttpMessageReader;
+import io.cloudevents.spring.webflux.CloudEventHttpMessageWriter;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.codec.CodecCustomizer;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.CodecConfigurer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.main.web-application-type=REACTIVE")
+class CloudFunctionTests {
+
+	@Autowired
+	private TestRestTemplate rest;
+
+	@LocalServerPort
+	private int port;
+
+	@Test
+	void echoWithCorrectHeaders() {
+
+		ResponseEntity<String> response = rest.exchange(RequestEntity.post(URI.create("http://localhost:" + port + "/")) //
+				.header("ce-id", "12345") //
+				.header("ce-specversion", "1.0") //
+				.header("ce-type", "io.spring.event") //
+				.header("ce-source", "https://spring.io/events") //
+				.contentType(MediaType.APPLICATION_JSON) //
+				.body("{\"value\":\"Dave\"}"), String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isEqualTo("{\"value\":\"Dave\"}");
+
+		HttpHeaders headers = response.getHeaders();
+
+		assertThat(headers).containsKey("ce-id");
+		assertThat(headers).containsKey("ce-source");
+		assertThat(headers).containsKey("ce-type");
+
+		// assertThat(headers.getFirst("ce-id")).isNotEqualTo("12345");
+		assertThat(headers.getFirst("ce-type")).isEqualTo("io.spring.event.Foo");
+		assertThat(headers.getFirst("ce-source")).isEqualTo("https://spring.io/foos");
+
+	}
+
+	@SpringBootApplication
+	static class TestApplication {
+
+		@Bean
+		public Function<CloudEvent, CloudEvent> events() {
+			return event -> CloudEventBuilder.from(event).withId(UUID.randomUUID().toString())
+					.withSource(URI.create("https://spring.io/foos")).withType("io.spring.event.Foo")
+					.withData(event.getData().toBytes()).build();
+		}
+
+		@Configuration
+		public static class CloudEventMessageConverterConfiguration {
+
+			@Bean
+			public CloudEventMessageConverter cloudEventMessageConverter() {
+				return new CloudEventMessageConverter();
+			}
+
+		}
+
+		@Configuration
+		public static class CloudEventHandlerConfiguration implements CodecCustomizer {
+
+			@Override
+			public void customize(CodecConfigurer configurer) {
+				configurer.customCodecs().register(new CloudEventHttpMessageReader());
+				configurer.customCodecs().register(new CloudEventHttpMessageWriter());
+			}
+
+		}
+
+	}
+
+}
+
+class Foo {
+
+	private String value;
+
+	public Foo() {
+	}
+
+	public Foo(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return "Foo [value=" + this.value + "]";
+	}
+
+}

--- a/spring/src/test/java/io/cloudevents/spring/mvc/MvcRestControllerTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/mvc/MvcRestControllerTests.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.mvc;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.spring.core.CloudEventHeaderUtils;
+import io.cloudevents.spring.http.CloudEventHttpUtils;
+import io.cloudevents.spring.mvc.CloudEventHttpMessageConverter;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class MvcRestControllerTests {
+
+	@Autowired
+	private TestRestTemplate rest;
+
+	@LocalServerPort
+	private int port;
+
+	@Test
+	void echoWithCorrectHeaders() {
+
+		ResponseEntity<String> response = rest.exchange(RequestEntity.post(URI.create("http://localhost:" + port + "/")) //
+				.header("ce-id", "12345") //
+				.header("ce-specversion", "1.0") //
+				.header("ce-type", "io.spring.event") //
+				.header("ce-source", "https://spring.io/events") //
+				.contentType(MediaType.APPLICATION_JSON) //
+				.body("{\"value\":\"Dave\"}"), String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isEqualTo("{\"value\":\"Dave\"}");
+
+		HttpHeaders headers = response.getHeaders();
+
+		assertThat(headers).containsKey("ce-id");
+		assertThat(headers).containsKey("ce-source");
+		assertThat(headers).containsKey("ce-type");
+
+		// assertThat(headers.getFirst("ce-id")).isNotEqualTo("12345");
+		assertThat(headers.getFirst("ce-type")).isEqualTo("io.spring.event.Foo");
+		assertThat(headers.getFirst("ce-source")).isEqualTo("https://spring.io/foos");
+
+	}
+
+	@Test
+	void structured() {
+
+		ResponseEntity<String> response = rest.exchange(RequestEntity.post(URI.create("http://localhost:" + port + "/")) //
+				.contentType(new MediaType("application", "cloudevents+json")) //
+				.body("{" //
+						+ "\"id\":\"12345\"," //
+						+ "\"specversion\":\"1.0\"," //
+						+ "\"type\":\"io.spring.event\"," //
+						+ "\"source\":\"https://spring.io/events\"," //
+						+ "\"data\":{\"value\":\"Dave\"}}"),
+				String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isEqualTo("{\"value\":\"Dave\"}");
+
+		HttpHeaders headers = response.getHeaders();
+
+		assertThat(headers).containsKey("ce-id");
+		assertThat(headers).containsKey("ce-source");
+		assertThat(headers).containsKey("ce-type");
+
+		// assertThat(headers.getFirst("ce-id")).isNotEqualTo("12345");
+		assertThat(headers.getFirst("ce-type")).isEqualTo("io.spring.event.Foo");
+		assertThat(headers.getFirst("ce-source")).isEqualTo("https://spring.io/foos");
+
+	}
+
+	@Test
+	void requestResponseEvents() {
+
+		ResponseEntity<String> response = rest
+				.exchange(RequestEntity.post(URI.create("http://localhost:" + port + "/event")) //
+						.header("ce-id", "12345") //
+						.header("ce-specversion", "1.0") //
+						.header("ce-type", "io.spring.event") //
+						.header("ce-source", "https://spring.io/events") //
+						.contentType(MediaType.APPLICATION_JSON) //
+						.body("{\"value\":\"Dave\"}"), String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isEqualTo("{\"value\":\"Dave\"}");
+
+		HttpHeaders headers = response.getHeaders();
+
+		assertThat(headers).containsKey("ce-id");
+		assertThat(headers).containsKey("ce-source");
+		assertThat(headers).containsKey("ce-type");
+
+		// assertThat(headers.getFirst("ce-id")).isNotEqualTo("12345");
+		assertThat(headers.getFirst("ce-type")).isEqualTo("io.spring.event.Foo");
+		assertThat(headers.getFirst("ce-source")).isEqualTo("https://spring.io/foos");
+
+	}
+
+	@SpringBootApplication
+	@RestController
+	static class TestApplication {
+
+		@PostMapping("/")
+		public ResponseEntity<Foo> echo(@RequestBody Foo foo, @RequestHeader HttpHeaders headers) {
+			CloudEvent attributes = CloudEventHttpUtils.fromHttp(headers).withId(UUID.randomUUID().toString())
+					.withSource(URI.create("https://spring.io/foos")).withType("io.spring.event.Foo").build();
+			HttpHeaders outgoing = CloudEventHttpUtils.toHttp(attributes);
+			return ResponseEntity.ok().headers(outgoing).body(foo);
+		}
+
+		@PostMapping(path = "/", consumes = "application/cloudevents+json")
+		public ResponseEntity<Object> structured(@RequestBody Map<String, Object> body,
+				@RequestHeader HttpHeaders headers) {
+			CloudEvent attributes = CloudEventHeaderUtils.fromMap(body).withId(UUID.randomUUID().toString())
+					.withSource(URI.create("https://spring.io/foos")).withType("io.spring.event.Foo").build();
+			HttpHeaders outgoing = CloudEventHttpUtils.toHttp(attributes);
+			return ResponseEntity.ok().headers(outgoing).body(body.get(CloudEventHeaderUtils.DATA));
+		}
+
+		@PostMapping("/event")
+		public CloudEvent ce(@RequestBody CloudEvent event) {
+			CloudEvent attributes = CloudEventBuilder.from(event).withId(UUID.randomUUID().toString())
+					.withSource(URI.create("https://spring.io/foos")).withType("io.spring.event.Foo")
+					.withData(event.getData().toBytes()).build();
+			return attributes;
+		}
+
+		@Configuration
+		public static class CloudEventHandlerConfiguration implements WebMvcConfigurer {
+
+			@Override
+			public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+				converters.add(0, new CloudEventHttpMessageConverter());
+			}
+
+		}
+
+	}
+
+}
+
+class Foo {
+
+	private String value;
+
+	public Foo() {
+	}
+
+	public Foo(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return "Foo [value=" + this.value + "]";
+	}
+
+}

--- a/spring/src/test/java/io/cloudevents/spring/webflux/WebFluxRestControllerTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/webflux/WebFluxRestControllerTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.webflux;
+
+import java.net.URI;
+import java.util.UUID;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.spring.http.CloudEventHttpUtils;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.codec.CodecCustomizer;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.CodecConfigurer;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.main.web-application-type=REACTIVE")
+class WebFluxRestControllerTests {
+
+	@Autowired
+	private TestRestTemplate rest;
+
+	@LocalServerPort
+	private int port;
+
+	@Test
+	void echoWithCorrectHeaders() {
+
+		ResponseEntity<String> response = rest.exchange(RequestEntity.post(URI.create("http://localhost:" + port + "/")) //
+				.header("ce-id", "12345") //
+				.header("ce-specversion", "1.0") //
+				.header("ce-type", "io.spring.event") //
+				.header("ce-source", "https://spring.io/events") //
+				.contentType(MediaType.APPLICATION_JSON) //
+				.body("{\"value\":\"Dave\"}"), String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isEqualTo("{\"value\":\"Dave\"}");
+
+		HttpHeaders headers = response.getHeaders();
+
+		assertThat(headers).containsKey("ce-id");
+		assertThat(headers).containsKey("ce-source");
+		assertThat(headers).containsKey("ce-type");
+
+		// assertThat(headers.getFirst("ce-id")).isNotEqualTo("12345");
+		assertThat(headers.getFirst("ce-type")).isEqualTo("io.spring.event.Foo");
+		assertThat(headers.getFirst("ce-source")).isEqualTo("https://spring.io/foos");
+
+	}
+
+	@Test
+	void requestResponseEvents() {
+
+		ResponseEntity<String> response = rest
+				.exchange(RequestEntity.post(URI.create("http://localhost:" + port + "/event")) //
+						.header("ce-id", "12345") //
+						.header("ce-specversion", "1.0") //
+						.header("ce-type", "io.spring.event") //
+						.header("ce-source", "https://spring.io/events") //
+						.contentType(MediaType.APPLICATION_JSON) //
+						.body("{\"value\":\"Dave\"}"), String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isEqualTo("{\"value\":\"Dave\"}");
+
+		HttpHeaders headers = response.getHeaders();
+
+		assertThat(headers).containsKey("ce-id");
+		assertThat(headers).containsKey("ce-source");
+		assertThat(headers).containsKey("ce-type");
+
+		// assertThat(headers.getFirst("ce-id")).isNotEqualTo("12345");
+		assertThat(headers.getFirst("ce-type")).isEqualTo("io.spring.event.Foo");
+		assertThat(headers.getFirst("ce-source")).isEqualTo("https://spring.io/foos");
+
+	}
+
+	@SpringBootApplication
+	@RestController
+	static class TestApplication {
+
+		@PostMapping("/")
+		public ResponseEntity<Foo> echo(@RequestBody Foo foo, @RequestHeader HttpHeaders headers) {
+			CloudEvent attributes = CloudEventHttpUtils.fromHttp(headers).withId(UUID.randomUUID().toString())
+					.withSource(URI.create("https://spring.io/foos")).withType("io.spring.event.Foo").build();
+			HttpHeaders outgoing = CloudEventHttpUtils.toHttp(attributes);
+			return ResponseEntity.ok().headers(outgoing).body(foo);
+		}
+
+		@PostMapping("/event")
+		public Mono<CloudEvent> event(@RequestBody Mono<CloudEvent> body) {
+			return body.map(event -> CloudEventBuilder.from(event).withId(UUID.randomUUID().toString())
+					.withSource(URI.create("https://spring.io/foos")).withType("io.spring.event.Foo")
+					.withData(event.getData().toBytes()).build());
+		}
+
+		@Configuration
+		public static class CloudEventHandlerConfiguration implements CodecCustomizer {
+
+			@Override
+			public void customize(CodecConfigurer configurer) {
+				configurer.customCodecs().register(new CloudEventHttpMessageReader());
+				configurer.customCodecs().register(new CloudEventHttpMessageWriter());
+			}
+
+		}
+
+	}
+
+}
+
+class Foo {
+
+	private String value;
+
+	public Foo() {
+	}
+
+	public Foo(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return "Foo [value=" + this.value + "]";
+	}
+
+}


### PR DESCRIPTION
This PR is the result of collaboration between Dave Syer(@dsyer) and Oleg Zhurakousky(@olegz) of Spring team (VMware).

It provides initial set of utility classes and interfaces to simplify integration of Cloud Events across many Spring projects

This PR duplicates and extends #293. It's an alternative implementation using the core java Cloud Events SDK. 
The examples have been omitted for brevity (and to prevent issues arising with snapshots and Spring Cloud Function).
Of interest is probably the new features that allow `@MVC` and WebFlux users to interact directly with `CloudEvent` if the choose to. Example (as per the tests in the spring module):

```java
		@PostMapping("/event")
		public CloudEvent ce(@RequestBody CloudEvent event) {
			CloudEvent attributes = CloudEventBuilder.from(event).withId(UUID.randomUUID().toString())
					.withSource(URI.create("https://spring.io/foos")).withType("io.spring.event.Foo")
					.withData(event.getData().toBytes()).build();
			return attributes;
		}
```