### PR TITLE
[Vertx] Fail promise on create reader exception

### DIFF
--- a/http/vertx/src/main/java/io/cloudevents/http/vertx/VertxMessageFactory.java
+++ b/http/vertx/src/main/java/io/cloudevents/http/vertx/VertxMessageFactory.java
@@ -67,7 +67,7 @@ public final class VertxMessageFactory {
         request.bodyHandler(b -> {
             try {
                 prom.complete(createReader(request.headers(), b));
-            } catch (IllegalArgumentException e) {
+            } catch (final Exception e) {
                 prom.fail(e);
             }
         });


### PR DESCRIPTION
When a request contains an invalid event, the body handler doesn't
handle the exception, which leads to an unhandled exception.

```
SEVERE: Unhandled exception
io.cloudevents.rw.CloudEventRWException: Invalid specversion: 9000.1
	at io.cloudevents.rw.CloudEventRWException.newInvalidSpecVersion(CloudEventRWException.java:87)
	at io.cloudevents.SpecVersion.parse(SpecVersion.java:76)
	at io.cloudevents.core.message.impl.MessageUtils.parseStructuredOrBinaryMessage(MessageUtils.java:57)
	at io.cloudevents.http.vertx.VertxMessageFactory.createReader(VertxMessageFactory.java:42)
	at io.cloudevents.http.vertx.VertxMessageFactory.lambda$createReader$4(VertxMessageFactory.java:63)
	at io.vertx.core.impl.future.FutureImpl$1.onSuccess(FutureImpl.java:91)
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:53)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:83)
	at io.vertx.core.impl.DuplicatedContext.execute(DuplicatedContext.java:199)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:50)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:180)
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23)
	at io.vertx.core.http.impl.HttpEventHandler.handleEnd(HttpEventHandler.java:79)
	at io.vertx.core.http.impl.Http1xServerRequest.onEnd(Http1xServerRequest.java:549)
	at io.vertx.core.http.impl.Http1xServerRequest.handleEnd(Http1xServerRequest.java:535)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:73)
	at io.vertx.core.impl.DuplicatedContext.execute(DuplicatedContext.java:189)
	at io.vertx.core.http.impl.Http1xServerConnection.onEnd(Http1xServerConnection.java:200)
	at io.vertx.core.http.impl.Http1xServerConnection.onContent(Http1xServerConnection.java:187)
	at io.vertx.core.http.impl.Http1xServerConnection.handleOther(Http1xServerConnection.java:156)
	at io.vertx.core.http.impl.Http1xServerConnection.handleMessage(Http1xServerConnection.java:144)
	at io.vertx.core.net.impl.ConnectionBase.read(ConnectionBase.java:151)
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:144)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler.channelRead(WebSocketServerExtensionHandler.java:101)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.vertx.core.http.impl.Http1xOrH2CHandler.end(Http1xOrH2CHandler.java:61)
	at io.vertx.core.http.impl.Http1xOrH2CHandler.channelRead(Http1xOrH2CHandler.java:38)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:714)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:576)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
```

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>