### PR TITLE
Fix 404 Not Found in AMQP module Readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ _site/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
+
+# MacOS
+*.DS_Store

--- a/amqp/README.md
+++ b/amqp/README.md
@@ -31,5 +31,5 @@ public class ProtonAmqpMessageFactory {
 Examples:
 
 The example uses the vertx-proton integration to send/receive CloudEvent messages over AMQP.
-* [Vertx AmqpServer](../../examples/amqp-proton/src/main/java/io/cloudevents/examples/amqp/vertx/AmqpServer.java)
-* [Vertx AmqpClient](../../examples/amqp-proton/src/main/java/io/cloudevents/examples/amqp/vertx/AmqpClient.java)
+* [Vertx AmqpServer](../examples/amqp-proton/src/main/java/io/cloudevents/examples/amqp/vertx/AmqpServer.java)
+* [Vertx AmqpClient](../examples/amqp-proton/src/main/java/io/cloudevents/examples/amqp/vertx/AmqpClient.java)


### PR DESCRIPTION
The path to the example client and server files specified in the amqp-proton Readme.md file is wrong and leads to a `404 Not Found` error when the link is visited.

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>