### PR TITLE
Jackson javadocs

### DIFF
--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 /**
  * Jackson {@link com.fasterxml.jackson.databind.JsonDeserializer} for {@link CloudEvent}
  */
-public class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
+class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
 
     protected CloudEventDeserializer() {
         super(CloudEvent.class);

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
@@ -33,7 +33,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * Jackson {@link com.fasterxml.jackson.databind.JsonSerializer} for {@link CloudEvent}
  */
-public class CloudEventSerializer extends StdSerializer<CloudEvent> {
+class CloudEventSerializer extends StdSerializer<CloudEvent> {
 
     private final boolean forceDataBase64Serialization;
     private final boolean forceStringSerialization;

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
@@ -29,7 +29,11 @@ public class JsonCloudEventData implements CloudEventData {
 
     private final JsonNode node;
 
-    JsonCloudEventData(JsonNode node) {
+    /**
+     * @param node the json node to wrap
+     * @deprecated You should use {@link #wrap(JsonNode)}
+     */
+    public JsonCloudEventData(JsonNode node) {
         Objects.requireNonNull(node);
         this.node = node;
     }

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonCloudEventData.java
@@ -23,13 +23,13 @@ import io.cloudevents.CloudEventData;
 import java.util.Objects;
 
 /**
- * This class is a wrapper for Jackson {@link JsonNode} implementing the {@link CloudEventData}
+ * This class is a wrapper for Jackson {@link JsonNode} implementing {@link CloudEventData}.
  */
 public class JsonCloudEventData implements CloudEventData {
 
     private final JsonNode node;
 
-    public JsonCloudEventData(JsonNode node) {
+    JsonCloudEventData(JsonNode node) {
         Objects.requireNonNull(node);
         this.node = node;
     }
@@ -39,6 +39,9 @@ public class JsonCloudEventData implements CloudEventData {
         return node.toString().getBytes();
     }
 
+    /**
+     * @return the wrapped {@link JsonNode}
+     */
     public JsonNode getNode() {
         return node;
     }
@@ -62,4 +65,13 @@ public class JsonCloudEventData implements CloudEventData {
             "node=" + node +
             '}';
     }
+
+    /**
+     * @param node the json node to wrap
+     * @return json node wrapped in a {@link JsonCloudEventData}, which implements {@link CloudEventData}.
+     */
+    public static JsonCloudEventData wrap(JsonNode node) {
+        return new JsonCloudEventData(node);
+    }
+
 }

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -33,15 +33,29 @@ import java.io.IOException;
 /**
  * Implementation of {@link EventFormat} for <a href="https://github.com/cloudevents/spec/blob/v1.0/json-format.md">JSON event format</a>
  * using Jackson. This format is resolvable with {@link io.cloudevents.core.provider.EventFormatProvider} using the content type {@link #CONTENT_TYPE}.
+ * <p>
+ * If you want to use the {@link CloudEvent} serializers/deserializers directly in your mapper, you can use {@link #getCloudEventJacksonModule()} or
+ * {@link #getCloudEventJacksonModule(boolean, boolean)} to get a {@link SimpleModule} to register in your {@link ObjectMapper} instance.
  */
 public final class JsonFormat implements EventFormat {
 
+    /**
+     * Content type associated with the JSON event format
+     */
     public static final String CONTENT_TYPE = "application/cloudevents+json";
 
     private final ObjectMapper mapper;
     private final boolean forceDataBase64Serialization;
     private final boolean forceStringSerialization;
 
+    /**
+     * Create a new instance of this class customizing the serialization configuration.
+     *
+     * @param forceDataBase64Serialization force json base64 encoding for data
+     * @param forceStringSerialization     force string serialization for non json data field
+     * @see #withForceJsonDataToBase64()
+     * @see #withForceNonJsonDataToString()
+     */
     public JsonFormat(boolean forceDataBase64Serialization, boolean forceStringSerialization) {
         this.mapper = new ObjectMapper();
         this.mapper.registerModule(getCloudEventJacksonModule(forceDataBase64Serialization, forceStringSerialization));
@@ -49,6 +63,9 @@ public final class JsonFormat implements EventFormat {
         this.forceStringSerialization = forceStringSerialization;
     }
 
+    /**
+     * Create a new instance of this class with default serialization configuration
+     */
     public JsonFormat() {
         this(false, false);
     }
@@ -106,15 +123,18 @@ public final class JsonFormat implements EventFormat {
     }
 
     /**
-     * @return a JacksonModule with CloudEvent serializer/deserializer with default values
+     * @return a {@link SimpleModule} with {@link CloudEvent} serializer/deserializer configured using default values.
      */
     public static SimpleModule getCloudEventJacksonModule() {
         return getCloudEventJacksonModule(false, false);
     }
 
     /**
+     * @param forceDataBase64Serialization force json base64 encoding for data
+     * @param forceStringSerialization force string serialization for non json data field
      * @return a JacksonModule with CloudEvent serializer/deserializer customizing the data serialization.
-     * Look at {@link #withForceJsonDataToBase64()} and {@link #withForceNonJsonDataToString()} for more details.
+     * @see #withForceJsonDataToBase64()
+     * @see #withForceNonJsonDataToString()
      */
     public static SimpleModule getCloudEventJacksonModule(boolean forceDataBase64Serialization, boolean forceStringSerialization) {
         final SimpleModule ceModule = new SimpleModule("CloudEvent");
@@ -123,7 +143,7 @@ public final class JsonFormat implements EventFormat {
         return ceModule;
     }
 
-    protected static boolean dataIsJsonContentType(String contentType) {
+    static boolean dataIsJsonContentType(String contentType) {
         // If content type, spec states that we should assume is json
         return contentType == null || contentType.startsWith("application/json") || contentType.startsWith("text/json");
     }

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/PojoCloudEventDataMapper.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/PojoCloudEventDataMapper.java
@@ -11,6 +11,11 @@ import io.cloudevents.rw.CloudEventRWException;
 
 import java.util.List;
 
+/**
+ * This class implements a {@link CloudEventDataMapper} that maps any input {@link CloudEventData} to the specified target type using the Jackson {@link ObjectMapper}.
+ *
+ * @param <T> the target type of the conversion
+ */
 public class PojoCloudEventDataMapper<T> implements CloudEventDataMapper<PojoCloudEventData<T>> {
 
     private final ObjectMapper mapper;

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
                         <link>https://jakarta.ee/specifications/platform/8/apidocs/</link>
                         <link>https://kafka.apache.org/25/javadoc/</link>
                         <link>https://qpid.apache.org/releases/qpid-proton-j-0.33.7/api/</link>
+                        <link>https://fasterxml.github.io/jackson-databind/javadoc/2.10/</link>
                     </links>
                 </configuration>
                 <executions>


### PR DESCRIPTION
* Added Jackson javadocs (fixing external linking too)
* Deprecated the constructor of `JsonCloudEventData` and added the `wrap` method (aligning with core data impls)
* Now `CloudEventSerializer` and `CloudEventDeserializer` classes are package privates (this shouldn't be a breaking change, because these classes had non public constructors anyway). Users can continue to use the `JsonFormat#getCloudEventJacksonModule` methods to register these constructors in their object mappers

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>