### PR TITLE
Add support for RSockets with Spring

### DIFF
--- a/docs/spring.md
+++ b/docs/spring.md
@@ -8,7 +8,7 @@ nav_order: 5
 [![Javadocs](http://www.javadoc.io/badge/io.cloudevents/cloudevents-spring.svg?color=green)](http://www.javadoc.io/doc/io.cloudevents/cloudevents-spring)
 
 This module provides the integration of `CloudEvent` with different Spring APIs,
-like MVC, WebFlux and Messaging
+like MVC, WebFlux, RSocket and Messaging
 
 For Maven based projects, use the following dependency:
 
@@ -43,3 +43,6 @@ Check out the samples:
 -   [spring-reactive](https://github.com/cloudevents/sdk-java/tree/master/examples/spring-reactive)
     shows how to receive and send CloudEvents through HTTP using Spring Boot and
     Webflux.
+
+-   [spring-rsocket](https://github.com/cloudevents/sdk-java/tree/master/examples/spring-rsocket)
+    shows how to receive and send CloudEvents through RSocket using Spring Boot.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,6 +26,7 @@
         <module>restful-ws-spring-boot</module>
         <module>amqp-proton</module>
         <module>spring-reactive</module>
+        <module>spring-rsocket</module>
     </modules>
 
 </project>

--- a/examples/spring-rsocket/README.md
+++ b/examples/spring-rsocket/README.md
@@ -1,0 +1,51 @@
+# Spring RSockets + CloudEvents sample
+
+## Build
+
+```shell
+mvn package
+```
+
+## Start Server
+
+```shell
+mvn spring-boot:run
+```
+
+You can try sending a request using [rsc](https://github.com/making/rsc), and it echos back a cloud event the same body and with new `ce-*` headers:
+
+```shell
+rsc --request --dataMimeType=application/cloudevents+json --route=event \
+    --data='{"data": {"value": "Foo"},
+           "id": "1", 
+           "source": "cloud-event-example", 
+           "type": "my.application.Foo", 
+           "specversion": "1.0"}' \
+    --debug tcp://localhost:7000
+```
+
+The `event` endpoint is implemented like this (the request and response are modelled directly as a `CloudEvent`):
+
+```java
+@MessageMapping("event")
+public Mono<CloudEvent> event(@RequestBody Mono<CloudEvent> body) {
+	return ...;
+}
+```
+
+and to make that work we need to install the codecs:
+
+```java
+@Bean
+@Order(-1)
+public RSocketStrategiesCustomizer cloudEventsCustomizer() {
+	return new RSocketStrategiesCustomizer() {
+		@Override
+		public void customize(Builder strategies) {
+			strategies.encoder(new CloudEventEncoder());
+			strategies.decoder(new CloudEventDecoder());
+		}
+	};
+
+}
+```

--- a/examples/spring-rsocket/pom.xml
+++ b/examples/spring-rsocket/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>cloudevents-spring-reactive-example</artifactId>
+    <artifactId>cloudevents-spring-rsocket-example</artifactId>
 
     <properties>
         <spring-boot.version>2.4.3</spring-boot.version>
@@ -30,16 +30,11 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webflux</artifactId>
+            <artifactId>spring-boot-starter-rsocket</artifactId>
         </dependency>
         <dependency>
             <groupId>io.cloudevents</groupId>
             <artifactId>cloudevents-spring</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.cloudevents</groupId>
-            <artifactId>cloudevents-http-basic</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/examples/spring-rsocket/src/main/java/io/cloudevents/examples/spring/DemoApplication.java
+++ b/examples/spring-rsocket/src/main/java/io/cloudevents/examples/spring/DemoApplication.java
@@ -1,0 +1,54 @@
+package io.cloudevents.examples.spring;
+
+import java.net.URI;
+import java.util.UUID;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.spring.codec.CloudEventDecoder;
+import io.cloudevents.spring.codec.CloudEventEncoder;
+import reactor.core.publisher.Mono;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.rsocket.messaging.RSocketStrategiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.rsocket.RSocketStrategies.Builder;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@SpringBootApplication
+@Controller
+public class DemoApplication {
+
+	public static void main(String[] args) throws Exception {
+		SpringApplication.run(DemoApplication.class, args);
+	}
+
+	@MessageMapping("event")
+	// Use CloudEvent API and manual type conversion of request and response body
+	public Mono<CloudEvent> event(@RequestBody Mono<CloudEvent> body) {
+		return body.map(event -> CloudEventBuilder.from(event) //
+				.withId(UUID.randomUUID().toString()) //
+				.withSource(URI.create("https://spring.io/foos")) //
+				.withType("io.spring.event.Foo") //
+				.withData(event.getData().toBytes()) //
+				.build());
+	}
+
+	@Bean
+	@Order(-1)
+	public RSocketStrategiesCustomizer cloudEventsCustomizer() {
+		return new RSocketStrategiesCustomizer() {
+			@Override
+			public void customize(Builder strategies) {
+				strategies.encoder(new CloudEventEncoder());
+				strategies.decoder(new CloudEventDecoder());
+			}
+		};
+
+	}
+
+}

--- a/examples/spring-rsocket/src/main/java/io/cloudevents/examples/spring/Foo.java
+++ b/examples/spring-rsocket/src/main/java/io/cloudevents/examples/spring/Foo.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.examples.spring;
+
+class Foo {
+
+	private String value;
+
+	public Foo() {
+	}
+
+	public Foo(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return "Foo [value=" + this.value + "]";
+	}
+
+}

--- a/examples/spring-rsocket/src/main/resources/application.properties
+++ b/examples/spring-rsocket/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.rsocket.server.port=7000

--- a/examples/spring-rsocket/src/test/java/io/cloudevents/examples/spring/DemoApplicationTests.java
+++ b/examples/spring-rsocket/src/test/java/io/cloudevents/examples/spring/DemoApplicationTests.java
@@ -1,0 +1,59 @@
+package io.cloudevents.examples.spring;
+
+import java.net.URI;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.data.PojoCloudEventData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.messaging.rsocket.RSocketRequester;
+import org.springframework.util.MimeType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class DemoApplicationTests {
+
+	@Autowired
+	private RSocketRequester.Builder builder;
+
+	@Autowired
+	private ObjectMapper mapper;
+
+	private RSocketRequester rsocketRequester;
+
+	@BeforeEach
+	public void init() {
+		String host = "localhost";
+		int port = 7000;
+		rsocketRequester = builder
+				.dataMimeType(MimeType.valueOf("application/cloudevents+json"))
+				.tcp(host, port);
+	}
+
+	@Test
+	void echoWithCorrectHeaders() {
+		CloudEvent result = rsocketRequester.route("event")
+				.data(CloudEventBuilder.v1()
+						.withDataContentType("application/cloudevents+json")
+						.withId(UUID.randomUUID().toString()) //
+						.withSource(URI.create("https://spring.io/foos")) //
+						.withType("io.spring.event.Foo") //
+						.withData(PojoCloudEventData.wrap(new Foo("Dave"),
+								foo -> mapper.writeValueAsBytes(foo)))
+						.build())
+				.retrieveMono(CloudEvent.class).block();
+
+		assertThat(new String(result.getData().toBytes()))
+				.isEqualTo("{\"value\":\"Dave\"}");
+
+	}
+
+}

--- a/examples/spring-rsocket/src/test/java/io/cloudevents/examples/spring/DemoApplicationTests.java
+++ b/examples/spring-rsocket/src/test/java/io/cloudevents/examples/spring/DemoApplicationTests.java
@@ -47,7 +47,7 @@ public class DemoApplicationTests {
 						.withSource(URI.create("https://spring.io/foos")) //
 						.withType("io.spring.event.Foo") //
 						.withData(PojoCloudEventData.wrap(new Foo("Dave"),
-								foo -> mapper.writeValueAsBytes(foo)))
+								mapper::writeValueAsBytes))
 						.build())
 				.retrieveMono(CloudEvent.class).block();
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <module-name>io.cloudevents.spring</module-name>
-        <spring-boot.version>2.4.0</spring-boot.version>
+        <spring-boot.version>2.4.3</spring-boot.version>
     </properties>
 
     <dependencyManagement>
@@ -77,6 +77,13 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 

--- a/spring/src/main/java/io/cloudevents/spring/codec/CloudEventDecoder.java
+++ b/spring/src/main/java/io/cloudevents/spring/codec/CloudEventDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2021-Present The CloudEvents Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.cloudevents.spring.codec;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.format.EventFormat;
@@ -35,13 +36,14 @@ import org.springframework.util.MimeTypeUtils;
 /**
  * Encoder for {@link CloudEvent CloudEvents}.
  *
- * @author Arjen Poutsma
- * @since 5.0
+ * @author Dave Syer
  */
 public class CloudEventDecoder extends AbstractDataBufferDecoder<CloudEvent> {
 
 	public CloudEventDecoder() {
-		super(MimeTypeUtils.ALL);
+		super(EventFormatProvider.getInstance().getContentTypes().stream()
+				.map(type -> MimeTypeUtils.parseMimeType(type))
+				.collect(Collectors.toList()).toArray(new MimeType[0]));
 	}
 
 	@Override

--- a/spring/src/main/java/io/cloudevents/spring/codec/CloudEventDecoder.java
+++ b/spring/src/main/java/io/cloudevents/spring/codec/CloudEventDecoder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudevents.spring.codec;
+
+import java.util.Map;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.format.EventFormat;
+import io.cloudevents.core.provider.EventFormatProvider;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.AbstractDataBufferDecoder;
+import org.springframework.core.codec.DecodingException;
+import org.springframework.core.codec.Hints;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.lang.Nullable;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+
+/**
+ * Encoder for {@link CloudEvent CloudEvents}.
+ *
+ * @author Arjen Poutsma
+ * @since 5.0
+ */
+public class CloudEventDecoder extends AbstractDataBufferDecoder<CloudEvent> {
+
+	public CloudEventDecoder() {
+		super(MimeTypeUtils.ALL);
+	}
+
+	@Override
+	public boolean canDecode(ResolvableType elementType, @Nullable MimeType mimeType) {
+		Class<?> clazz = elementType.toClass();
+		return super.canDecode(elementType, mimeType)
+				&& CloudEvent.class.isAssignableFrom(clazz) && EventFormatProvider
+						.getInstance().resolveFormat(mimeType.toString()) != null;
+	}
+
+	@Override
+	public CloudEvent decode(DataBuffer buffer, ResolvableType targetType,
+			MimeType mimeType, Map<String, Object> hints) throws DecodingException {
+		if (logger.isDebugEnabled() && !Hints.isLoggingSuppressed(hints)) {
+			String logPrefix = Hints.getLogPrefix(hints);
+			logger.debug(logPrefix + "Reading CloudEvent");
+		}
+		EventFormat format = EventFormatProvider.getInstance()
+				.resolveFormat(mimeType.toString());
+		byte[] result = new byte[buffer.readableByteCount()];
+		buffer.read(result);
+		DataBufferUtils.release(buffer);
+		return format.deserialize(result);
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/codec/CloudEventEncoder.java
+++ b/spring/src/main/java/io/cloudevents/spring/codec/CloudEventEncoder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudevents.spring.codec;
+
+import java.util.Map;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.format.EventFormat;
+import io.cloudevents.core.provider.EventFormatProvider;
+import reactor.core.publisher.Flux;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.AbstractSingleValueEncoder;
+import org.springframework.core.codec.Hints;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.lang.Nullable;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+
+/**
+ * Encoder for {@link CloudEvent CloudEvents}.
+ *
+ * @author Arjen Poutsma
+ * @since 5.0
+ */
+public class CloudEventEncoder extends AbstractSingleValueEncoder<CloudEvent> {
+
+	public CloudEventEncoder() {
+		super(MimeTypeUtils.APPLICATION_OCTET_STREAM, MimeTypeUtils.ALL);
+	}
+
+	@Override
+	public boolean canEncode(ResolvableType elementType, @Nullable MimeType mimeType) {
+		Class<?> clazz = elementType.toClass();
+		return super.canEncode(elementType, mimeType)
+				&& CloudEvent.class.isAssignableFrom(clazz) && EventFormatProvider
+						.getInstance().resolveFormat(mimeType.toString()) != null;
+	}
+
+	@Override
+	protected Flux<DataBuffer> encode(CloudEvent event, DataBufferFactory bufferFactory,
+			ResolvableType type, @Nullable MimeType mimeType,
+			@Nullable Map<String, Object> hints) {
+		return Flux.just(encodeValue(event, bufferFactory, type, mimeType, hints));
+	}
+
+	@Override
+	public DataBuffer encodeValue(CloudEvent event, DataBufferFactory bufferFactory,
+			ResolvableType valueType, MimeType mimeType, Map<String, Object> hints) {
+		if (logger.isDebugEnabled() && !Hints.isLoggingSuppressed(hints)) {
+			String logPrefix = Hints.getLogPrefix(hints);
+			logger.debug(logPrefix + "Writing [" + event + "]");
+		}
+		EventFormat format = EventFormatProvider.getInstance()
+				.resolveFormat(mimeType.toString());
+		return bufferFactory.wrap(format.serialize(event));
+	}
+
+}

--- a/spring/src/main/java/io/cloudevents/spring/codec/CloudEventEncoder.java
+++ b/spring/src/main/java/io/cloudevents/spring/codec/CloudEventEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2021-Present The CloudEvents Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.cloudevents.spring.codec;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.format.EventFormat;
@@ -35,13 +36,14 @@ import org.springframework.util.MimeTypeUtils;
 /**
  * Encoder for {@link CloudEvent CloudEvents}.
  *
- * @author Arjen Poutsma
- * @since 5.0
+ * @author Dave Syer
  */
 public class CloudEventEncoder extends AbstractSingleValueEncoder<CloudEvent> {
 
 	public CloudEventEncoder() {
-		super(MimeTypeUtils.APPLICATION_OCTET_STREAM, MimeTypeUtils.ALL);
+		super(EventFormatProvider.getInstance().getContentTypes().stream()
+				.map(type -> MimeTypeUtils.parseMimeType(type))
+				.collect(Collectors.toList()).toArray(new MimeType[0]));
 	}
 
 	@Override

--- a/spring/src/test/java/io/cloudevents/spring/codec/CloudEventDecoderTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/codec/CloudEventDecoderTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.codec;
+
+import java.net.URI;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.util.MimeTypeUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+class CloudEventDecoderTests {
+
+	@Test
+	void canDecodeJson() {
+		CloudEventDecoder decoder = new CloudEventDecoder();
+		assertThat(decoder.canDecode(ResolvableType.forClass(CloudEvent.class),
+				MimeTypeUtils.parseMimeType("application/cloudevents+json"))).isTrue();
+	}
+
+	@Test
+	void cannotDecodeUnsupported() {
+		CloudEventDecoder decoder = new CloudEventDecoder();
+		assertThat(decoder.canDecode(ResolvableType.forClass(CloudEvent.class),
+				MimeTypeUtils.parseMimeType("application/cloudevents+rubbish")))
+						.isFalse();
+	}
+
+	@Test
+	void doesDecodeJson() {
+		CloudEventDecoder decoder = new CloudEventDecoder();
+		CloudEventEncoder encoder = new CloudEventEncoder();
+		CloudEvent attributes = CloudEventBuilder.v1().withId("A234-1234-1234")
+				.withSource(URI.create("https://spring.io/"))
+				.withType("org.springframework")
+				.withData("{\"name\":\"hello\"}".getBytes()).build();
+		Flux<DataBuffer> value = encoder.encode(attributes,
+				DefaultDataBufferFactory.sharedInstance,
+				ResolvableType.forClass(CloudEvent.class),
+				MimeTypeUtils.parseMimeType("application/cloudevents+json"), null);
+		CloudEvent event = decoder
+				.decode(value, ResolvableType.forClass(CloudEvent.class),
+						MimeTypeUtils.parseMimeType("application/cloudevents+json"), null)
+				.blockLast();
+		assertThat(event.getId()).isEqualTo(attributes.getId());
+		assertThat(event.getData().toBytes()).isEqualTo(attributes.getData().toBytes());
+	}
+
+}

--- a/spring/src/test/java/io/cloudevents/spring/codec/CloudEventEncoderTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/codec/CloudEventEncoderTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudevents.spring.codec;
+
+import java.net.URI;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.util.MimeTypeUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+class CloudEventEncoderTests {
+
+	@Test
+	void canEncodeJson() {
+		CloudEventEncoder encoder = new CloudEventEncoder();
+		assertThat(encoder.canEncode(ResolvableType.forClass(CloudEvent.class),
+				MimeTypeUtils.parseMimeType("application/cloudevents+json"))).isTrue();
+	}
+
+	@Test
+	void cannotEncodeUnsupported() {
+		CloudEventEncoder encoder = new CloudEventEncoder();
+		assertThat(encoder.canEncode(ResolvableType.forClass(CloudEvent.class),
+				MimeTypeUtils.parseMimeType("application/cloudevents+rubbish")))
+						.isFalse();
+	}
+
+	@Test
+	void doesEncodeJson() {
+		CloudEventEncoder encoder = new CloudEventEncoder();
+		CloudEvent attributes = CloudEventBuilder.v1().withId("A234-1234-1234")
+				.withSource(URI.create("https://spring.io/"))
+				.withType("org.springframework").withData("hello".getBytes()).build();
+		Flux<DataBuffer> value = encoder.encode(attributes,
+				DefaultDataBufferFactory.sharedInstance,
+				ResolvableType.forClass(CloudEvent.class),
+				MimeTypeUtils.parseMimeType("application/cloudevents+json"), null);
+		byte[] array = value.blockLast().asByteBuffer().array();
+		String json = new String(array);
+		assertThat(json).contains("\"specversion\":\"1.0\"");
+	}
+
+}


### PR DESCRIPTION
Also generically can support structured events with any Spring
API that works with Encoder and Decoder. There's a sample for
the RSocket case with a simple request-response echo server.