### PR TITLE
Specification Compliant handling of numeric context attributes

### DIFF
--- a/api/src/main/java/io/cloudevents/rw/CloudEventContextWriter.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventContextWriter.java
@@ -83,8 +83,26 @@ public interface CloudEventContextWriter {
      * @return self
      * @throws CloudEventRWException if anything goes wrong while writing this extension.
      * @throws IllegalArgumentException if you're trying to set the specversion attribute.
+     *
+     * @deprecated CloudEvent specification only permits {@link Integer} type as a
+     * numeric value.
      */
     default CloudEventContextWriter withContextAttribute(String name, Number value) throws CloudEventRWException {
+        return withContextAttribute(name, value.toString());
+    }
+
+    /**
+     * Set attribute with type {@link Integer}.
+     * This setter should not be invoked for specversion, because the writer should
+     * already know the specversion or because it doesn't need it to correctly write the value.
+     *
+     * @param name  name of the attribute
+     * @param value value of the attribute
+     * @return self
+     * @throws CloudEventRWException if anything goes wrong while writing this extension.
+     * @throws IllegalArgumentException if you're trying to set the specversion attribute.
+     */
+    default CloudEventContextWriter withContextAttribute(String name, Integer value) throws CloudEventRWException {
         return withContextAttribute(name, value.toString());
     }
 

--- a/api/src/main/java/io/cloudevents/rw/CloudEventContextWriter.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventContextWriter.java
@@ -85,7 +85,7 @@ public interface CloudEventContextWriter {
      * @throws IllegalArgumentException if you're trying to set the specversion attribute.
      *
      * @deprecated CloudEvent specification only permits {@link Integer} type as a
-     * numeric value.
+     * numeric val
      */
     default CloudEventContextWriter withContextAttribute(String name, Number value) throws CloudEventRWException {
         return withContextAttribute(name, value.toString());

--- a/api/src/main/java/io/cloudevents/rw/CloudEventContextWriter.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventContextWriter.java
@@ -85,7 +85,7 @@ public interface CloudEventContextWriter {
      * @throws IllegalArgumentException if you're trying to set the specversion attribute.
      *
      * @deprecated CloudEvent specification only permits {@link Integer} type as a
-     * numeric val
+     * numeric value.
      */
     default CloudEventContextWriter withContextAttribute(String name, Number value) throws CloudEventRWException {
         return withContextAttribute(name, value.toString());

--- a/api/src/main/java/io/cloudevents/rw/CloudEventRWException.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventRWException.java
@@ -137,6 +137,17 @@ public class CloudEventRWException extends RuntimeException {
         );
     }
 
+    public static CloudEventRWException newInvalidAttributeType(String attributeName,Object value){
+        return new CloudEventRWException(
+            CloudEventRWExceptionKind.INVALID_ATTRIBUTE_TYPE,
+            "Invalid attribute/extension type for \""
+                + attributeName
+                + "\": Type" + value.getClass().getCanonicalName()
+                + ". Value: " + value
+
+        );
+    }
+
     /**
      * @param attributeName the invalid attribute name
      * @param value         the value of the attribute

--- a/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
@@ -247,6 +247,26 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
     }
 
     @Override
+    public CloudEventContextWriter withContextAttribute(String name, Integer value) throws CloudEventRWException
+    {
+        requireValidAttributeWrite(name);
+        switch (name) {
+            case TIME:
+            case SCHEMAURL:
+            case ID:
+            case TYPE:
+            case DATACONTENTTYPE:
+            case DATACONTENTENCODING:
+            case SUBJECT:
+            case SOURCE:
+                throw CloudEventRWException.newInvalidAttributeType(name, Integer.class);
+            default:
+                withExtension(name, value);
+                return this;
+        }
+    }
+
+    @Override
     public CloudEventContextWriter withContextAttribute(String name, Boolean value) throws CloudEventRWException {
         requireValidAttributeWrite(name);
         switch (name) {

--- a/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
@@ -239,6 +239,25 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
     }
 
     @Override
+    public CloudEventContextWriter withContextAttribute(String name, Integer value) throws CloudEventRWException
+    {
+        requireValidAttributeWrite(name);
+        switch (name) {
+            case TIME:
+            case DATASCHEMA:
+            case ID:
+            case TYPE:
+            case DATACONTENTTYPE:
+            case SUBJECT:
+            case SOURCE:
+                throw CloudEventRWException.newInvalidAttributeType(name, Integer.class);
+            default:
+                withExtension(name, value);
+                return this;
+        }
+    }
+
+    @Override
     public CloudEventContextWriter withContextAttribute(String name, Boolean value) throws CloudEventRWException {
         requireValidAttributeWrite(name);
         switch (name) {

--- a/core/src/test/java/io/cloudevents/core/test/Data.java
+++ b/core/src/test/java/io/cloudevents/core/test/Data.java
@@ -21,6 +21,7 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.types.Time;
 
+import java.math.BigDecimal;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -114,6 +115,16 @@ public class Data {
         .withType(TYPE)
         .withSource(SOURCE)
         .withExtension("binary", BINARY_VALUE)
+        .build();
+
+    public static final CloudEvent V1_WITH_NUMERIC_EXT = CloudEventBuilder.v1()
+        .withId(ID)
+        .withType(TYPE)
+        .withSource(SOURCE)
+        .withExtension("integer", 42)
+        .withExtension("decimal", new BigDecimal("42.42"))
+        .withExtension("float", 4.2f)
+        .withExtension("long", new Long(4200))
         .build();
 
     public static final CloudEvent V03_MIN = CloudEventBuilder.v03(V1_MIN).build();

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -134,7 +134,17 @@ class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
                             writer.withContextAttribute(extensionName, extensionValue.booleanValue());
                             break;
                         case NUMBER:
-                            writer.withContextAttribute(extensionName, extensionValue.numberValue());
+
+                            final Number numericValue = extensionValue.numberValue();
+
+                            // Only 'Int' values are supported by the specification
+
+                            if (numericValue instanceof Integer){
+                                writer.withContextAttribute(extensionName, (Integer) numericValue);
+                            } else{
+                                throw CloudEventRWException.newInvalidAttributeValue(extensionName,extensionValue, null);
+                            }
+
                             break;
                         case STRING:
                             writer.withContextAttribute(extensionName, extensionValue.textValue());

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -142,7 +142,7 @@ class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
                             if (numericValue instanceof Integer){
                                 writer.withContextAttribute(extensionName, (Integer) numericValue);
                             } else{
-                                throw CloudEventRWException.newInvalidAttributeValue(extensionName,extensionValue, null);
+                                throw CloudEventRWException.newInvalidAttributeType(extensionName,numericValue);
                             }
 
                             break;

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
@@ -65,15 +65,23 @@ class CloudEventSerializer extends StdSerializer<CloudEvent> {
         }
 
         @Override
-        public CloudEventContextWriter withContextAttribute(String name, Number value) throws CloudEventRWException {
+        public CloudEventContextWriter withContextAttribute(String name, Number value) throws CloudEventRWException
+        {
+            // Only Integer types are supported by the specification
+            if (value instanceof Integer) {
+                this.withContextAttribute(name, (Integer) value);
+            } else {
+                // Default to string representation for other numeric values
+                this.withContextAttribute(name, value.toString());
+            }
+            return this;
+        }
+
+        @Override
+        public CloudEventContextWriter withContextAttribute(String name, Integer value) throws CloudEventRWException
+        {
             try {
-                // Only Integer types are supported by the specification
-                if (value instanceof Integer) {
-                    gen.writeNumberField(name, value.intValue());
-                } else {
-                    // Default to string representation for other numeric values
-                    this.withContextAttribute(name, value.toString());
-                }
+                gen.writeNumberField(name, value.intValue());
                 return this;
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventSerializer.java
@@ -67,8 +67,13 @@ class CloudEventSerializer extends StdSerializer<CloudEvent> {
         @Override
         public CloudEventContextWriter withContextAttribute(String name, Number value) throws CloudEventRWException {
             try {
-                gen.writeFieldName(name);
-                provider.findValueSerializer(value.getClass()).serialize(value, gen, provider);
+                // Only Integer types are supported by the specification
+                if (value instanceof Integer) {
+                    gen.writeNumberField(name, value.intValue());
+                } else {
+                    // Default to string representation for other numeric values
+                    this.withContextAttribute(name, value.toString());
+                }
                 return this;
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
@@ -43,8 +43,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import static io.cloudevents.core.test.Data.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.*;
 
 class JsonFormatTest {
 
@@ -135,14 +134,7 @@ class JsonFormatTest {
         byte[] input = loadFile(inputFile);
         boolean exceptionThrown = false;
 
-        try {
-
-            CloudEvent ce = getFormat().deserialize(input);
-
-            Assertions.fail("Expected Exception did not occur");
-
-        } catch (EventDeserializationException ede){
-        }
+        assertThatExceptionOfType(EventDeserializationException.class).isThrownBy(() -> getFormat().deserialize(input));
 
     }
 

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
@@ -133,7 +133,8 @@ class JsonFormatTest {
             Arguments.of(V1_WITH_JSON_DATA_WITH_EXT, "v1/json_data_with_ext.json"),
             Arguments.of(V1_WITH_XML_DATA, "v1/base64_xml_data.json"),
             Arguments.of(V1_WITH_TEXT_DATA, "v1/base64_text_data.json"),
-            Arguments.of(V1_WITH_BINARY_EXT, "v1/binary_attr.json")
+            Arguments.of(V1_WITH_BINARY_EXT, "v1/binary_attr.json"),
+            Arguments.of(V1_WITH_NUMERIC_EXT,"v1/numeric_ext.json")
         );
     }
 

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
@@ -132,7 +132,6 @@ class JsonFormatTest {
     void verifyDeserializeError(String inputFile){
 
         byte[] input = loadFile(inputFile);
-        boolean exceptionThrown = false;
 
         assertThatExceptionOfType(EventDeserializationException.class).isThrownBy(() -> getFormat().deserialize(input));
 

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
@@ -24,14 +24,17 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.format.EventDeserializationException;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.rw.CloudEventRWException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -120,6 +123,29 @@ class JsonFormatTest {
             .hasMessageContaining(CloudEventRWException.newInvalidSpecVersion("9000.1").getMessage());
     }
 
+    @ParameterizedTest
+    @MethodSource("badJsonContent")
+    /**
+     * JSON content that should fail deserialization
+     * as it represents content that is not CE
+     * specification compliant.
+     */
+    void verifyDeserializeError(String inputFile){
+
+        byte[] input = loadFile(inputFile);
+        boolean exceptionThrown = false;
+
+        try {
+
+            CloudEvent ce = getFormat().deserialize(input);
+
+            Assertions.fail("Expected Exception did not occur");
+
+        } catch (EventDeserializationException ede){
+        }
+
+    }
+
     public static Stream<Arguments> serializeTestArgumentsDefault() {
         return Stream.of(
             Arguments.of(V03_MIN, "v03/min.json"),
@@ -198,6 +224,15 @@ class JsonFormatTest {
             "v1/json_data.json",
             "v1/base64_xml_data.json",
             "v1/base64_text_data.json"
+        );
+    }
+
+    public static Stream<String> badJsonContent() {
+        return Stream.of(
+            "v03/fail_numeric_decimal.json",
+            "v03/fail_numeric_long.json",
+            "v1/fail_numeric_decimal.json",
+            "v1/fail_numeric_long.json"
         );
     }
 

--- a/formats/json-jackson/src/test/resources/v03/fail_numeric_decimal.json
+++ b/formats/json-jackson/src/test/resources/v03/fail_numeric_decimal.json
@@ -1,0 +1,7 @@
+{
+    "specversion": "1.0",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "decimal": 42.42
+}

--- a/formats/json-jackson/src/test/resources/v03/fail_numeric_long.json
+++ b/formats/json-jackson/src/test/resources/v03/fail_numeric_long.json
@@ -1,0 +1,7 @@
+{
+    "specversion": "1.0",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "long": 4247483647
+}

--- a/formats/json-jackson/src/test/resources/v1/fail_numeric_decimal.json
+++ b/formats/json-jackson/src/test/resources/v1/fail_numeric_decimal.json
@@ -1,0 +1,7 @@
+{
+    "specversion": "1.0",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "decimal": 42.42
+}

--- a/formats/json-jackson/src/test/resources/v1/fail_numeric_long.json
+++ b/formats/json-jackson/src/test/resources/v1/fail_numeric_long.json
@@ -1,0 +1,7 @@
+{
+    "specversion": "1.0",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "long": 4247483647
+}

--- a/formats/json-jackson/src/test/resources/v1/numeric_ext.json
+++ b/formats/json-jackson/src/test/resources/v1/numeric_ext.json
@@ -1,0 +1,10 @@
+{
+    "specversion": "1.0",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "integer": 42,
+    "decimal": "42.42",
+    "float": "4.2",
+    "long": "4200"
+}


### PR DESCRIPTION
- Added tests case to verify expected handling of numeric context attributes.
- Updated serializer.

Ideally we'd change the `CloudEventContextWriter` and replace the set(name, Number) method with a set(name, Integer) method to ensure that all future implementations.

I'm happy to make that change now based on feedback.

Closes #357 

Signed-off-by: Day, Jeremy(jday) <jday@paypal.com>