### PR TITLE
Throw exceptions when attempting to handle unsupported CloudEvent formats

### DIFF
--- a/core/src/main/java/io/cloudevents/core/message/impl/MessageUtils.java
+++ b/core/src/main/java/io/cloudevents/core/message/impl/MessageUtils.java
@@ -59,6 +59,15 @@ public class MessageUtils {
             EventFormat format = EventFormatProvider.getInstance().resolveFormat(ct);
             if (format != null) {
                 return structuredMessageFactory.apply(format);
+            } else {
+                /**
+                 * The format wasn't one we support, but if it's part of the
+                 * CloudEvent family it indicates it's a structured
+                 * representation that we can't interpret.
+                 */
+                if (ct.startsWith("application/cloudevents")) {
+                    throw newUnknownEncodingException();
+                }
             }
         }
 

--- a/core/src/test/java/io/cloudevents/core/message/impl/MessageUtilsTest.java
+++ b/core/src/test/java/io/cloudevents/core/message/impl/MessageUtilsTest.java
@@ -27,6 +27,25 @@ class MessageUtilsTest {
             .isEqualTo(CloudEventRWException.CloudEventRWExceptionKind.UNKNOWN_ENCODING);
     }
 
+
+    /**
+     * Verify an exception is thrown if an unsupported
+     * application/cloudevents content-type family is
+     * received.
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testBadContentTypes(String contentType) {
+
+        CloudEventRWException exception = assertThrows(CloudEventRWException.class, () ->
+        {
+            parseStructuredOrBinaryMessage(() -> contentType, eventFormat -> null, () -> "1.0", specVersion -> null);
+        });
+
+        assertThat(exception.getKind()).isEqualTo(CloudEventRWException.CloudEventRWExceptionKind.UNKNOWN_ENCODING);
+
+    }
+
     @Test
     void testParseStructuredOrBinaryMessage_StructuredMode() {
         MessageUtils.parseStructuredOrBinaryMessage(() -> "application/cloudevents+csv;",
@@ -51,6 +70,13 @@ class MessageUtilsTest {
         return Stream.of(
             Arguments.of("0.3", V03),
             Arguments.of("1.0", V1)
+        );
+    }
+
+    private static Stream<Arguments> testBadContentTypes() {
+        return Stream.of(
+            Arguments.of("application/cloudevents"),
+            Arguments.of("application/cloudevents+morse")
         );
     }
 


### PR DESCRIPTION

- Modfy logic that selects between structured and binary modes during reception.
- Introduced new test scenarios to veify behavior.

Closes #361 

Signed-off-by: Day, Jeremy(jday) <jday@paypal.com>