### PR TITLE
CloudEvents attribute names SHOULD NOT exceed 20 chars

### DIFF
--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -23,7 +23,6 @@ import io.cloudevents.CloudEventData;
 import io.cloudevents.CloudEventExtension;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.data.BytesCloudEventData;
-import io.cloudevents.rw.CloudEventContextWriter;
 import io.cloudevents.rw.CloudEventRWException;
 
 import javax.annotation.Nonnull;
@@ -198,9 +197,6 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
      * @see <a href="https://github.com/cloudevents/spec/blob/master/spec.md#attribute-naming-convention">attribute-naming-convention</a>
      */
     private static boolean isValidExtensionName(String name) {
-        if(name.length() > 20){
-            return false;
-        }
         char[] chars = name.toCharArray();
         for (char c : chars)
             if (!isValidChar(c)) {

--- a/core/src/test/java/io/cloudevents/core/impl/BaseCloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/impl/BaseCloudEventBuilderTest.java
@@ -1,14 +1,17 @@
 package io.cloudevents.core.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.extensions.DistributedTracingExtension;
 import io.cloudevents.core.test.Data;
+import org.junit.jupiter.api.Test;
 
 public class BaseCloudEventBuilderTest {
 
@@ -48,17 +51,23 @@ public class BaseCloudEventBuilderTest {
     }
 
     @Test
-    public void testLongExtensionName() {
-        Exception exception = assertThrows(RuntimeException.class, () -> {
-            CloudEvent cloudEvent = CloudEventBuilder.v1(Data.V1_WITH_JSON_DATA_WITH_EXT)
+    public void testLongExtensionNameV1() {
+        assertDoesNotThrow(() -> {
+            CloudEventBuilder.v1(Data.V1_WITH_JSON_DATA_WITH_EXT)
                 .withExtension("thisextensionnameistoolong", "")
                 .build();
         });
-        String expectedMessage = "Invalid extensions name: thisextensionnameistoolong";
-        String actualMessage = exception.getMessage();
-
-        assertTrue(actualMessage.contains(expectedMessage));
     }
+
+    @Test
+    public void testLongExtensionNameV03() {
+        assertDoesNotThrow(() -> {
+            CloudEventBuilder.v03(Data.V1_WITH_JSON_DATA_WITH_EXT)
+                .withExtension("thisextensionnameistoolong", "")
+                .build();
+        });
+    }
+
     @Test
     public void testInvalidExtensionName() {
         Exception exception = assertThrows(RuntimeException.class, () -> {


### PR DESCRIPTION
As per spec [1], attribute names SHOULD NOT and not MUST NOT
exceed 20 characters in length.

[1] https://github.com/cloudevents/spec/blob/master/spec.md#attribute-naming-convention