### PR TITLE
Avoid allocating an array on extension validation

### DIFF
--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -201,11 +201,11 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
         if(name.length() > 20){
             return false;
         }
-        char[] chars = name.toCharArray();
-        for (char c : chars)
-            if (!isValidChar(c)) {
+        for(int i = 0; i < name.length(); i++) {
+            if (!isValidChar(name.charAt(i))) {
                 return false;
             }
+        }
         return true;
     }
 


### PR DESCRIPTION
As per title.
There is no need to allocate another array.