### PR TITLE
implement MessageReader for Paho MQTT

### DIFF
--- a/mqtt/paho/pom.xml
+++ b/mqtt/paho/pom.xml
@@ -1,0 +1,72 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.cloudevents</groupId>
+    <artifactId>cloudevents-parent</artifactId>
+    <version>2.1.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <artifactId>cloudevents-mqtt-paho</artifactId>
+  <name>CloudEvents - Paho MQTT Binding</name>
+  <packaging>jar</packaging>
+  
+  <properties>
+     <paho.version>1.2.5</paho.version>
+     <module-name>io.cloudevents.mqtt.paho</module-name>
+  </properties>
+  
+  <dependencies>
+  	  <dependency>
+  	  	  <groupId>io.cloudevents</groupId>
+  	  	  <artifactId>cloudevents-core</artifactId>
+  	  	  <version>${project.version}</version>
+  	  </dependency>
+  	  <dependency>
+	      <groupId>io.cloudevents</groupId>
+	      <artifactId>cloudevents-json-jackson</artifactId>
+	      <version>${project.version}</version>
+	  </dependency>
+
+      <!-- Paho MQTTv5 client  -->
+      <dependency>
+          <groupId>org.eclipse.paho</groupId>
+          <artifactId>org.eclipse.paho.mqttv5.client</artifactId>
+          <version>${paho.version}</version>
+      </dependency>
+      <!-- Paho MQTTv3 client -->
+	  <dependency>
+         <groupId>org.eclipse.paho</groupId>
+         <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+         <version>${paho.version}</version>
+      </dependency>
+
+	  <!-- test dependencies -->
+	  <dependency>
+			<groupId>io.cloudevents</groupId>
+			<artifactId>cloudevents-core</artifactId>
+			<classifier>tests</classifier>
+			<type>test-jar</type>
+			<version>${project.version}</version>
+			<scope>test</scope>
+	  </dependency>
+	  <dependency>
+	      <groupId>org.junit.jupiter</groupId>
+		  <artifactId>junit-jupiter</artifactId>
+		  <version>${junit-jupiter.version}</version>
+	  </dependency>
+	  <dependency>
+		  <groupId>org.assertj</groupId>
+		  <artifactId>assertj-core</artifactId>
+		  <version>${assertj-core.version}</version>
+		  <scope>test</scope>
+	  </dependency>
+	  <!--<dependency>
+	      <groupId>io.cloudevents</groupId>
+	      <artifactId>cloudevents-json-jackson</artifactId>
+	      <version>${project.version}</version>
+	      <classifier>tests</classifier>
+		  <type>test-jar</type>
+	      <scope>test</scope>
+	  </dependency>-->
+  </dependencies>
+</project>

--- a/mqtt/paho/src/main/java/io/cloudevents/mqtt/MqttMessageFactory.java
+++ b/mqtt/paho/src/main/java/io/cloudevents/mqtt/MqttMessageFactory.java
@@ -1,0 +1,77 @@
+package io.cloudevents.mqtt;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.message.MessageReader;
+import io.cloudevents.core.message.MessageWriter;
+import io.cloudevents.rw.CloudEventRWException;
+
+/**
+ * A factory class providing convenience methods for creating {@link MessageReader} and {@link MessageWriter} instances based on the Paho MQTT library.
+ * <p>
+ * The MQTT protocol binding spec mandates that MQTTv3 messages be translated to Structured CloudEvent messages while MQTTv3 messages can be translated
+ * either to Structured or Binary content modes depending on the payload format of the message.
+ */
+public class MqttMessageFactory {
+
+    private MqttMessageFactory() {
+        // prevent instantiation
+    }
+
+    /**
+     * Creates a {@link MessageReader} instance for the given MQTTv5 message.
+     * <p>
+     * The MessageReader is capable of translating the message to either a Structured or Binary CloudEvent.
+     * 
+     * @param message                An MQTTv5 message.
+     * @return                       A new MessageReader instance capable of reading the given message to a (Structured/Binary) CloudEvent.
+     * @throws CloudEventRWException if something goes wrong while resolving the {@link SpecVersion} or if the message has an unknown encoding.
+     */
+    public static MessageReader createReader(final org.eclipse.paho.mqttv5.common.MqttMessage message) {
+        return createReader(MqttVersion.MQTTV5, message.getProperties().getContentType(), message.getProperties().getUserProperties(), message.getPayload());
+    }
+
+    /**
+     * Creates a {@link MessageReader} instance for the given MQTTv3 message.
+     * <p>
+     * The MessageReader is capable of translating the message to a Structured CloudEvent only.
+     * 
+     * @param message   An MQTTv3 message.
+     * @return          A new MessageReader instance capable of reading the given message to a Structured CloudEvent.
+     * @throws CloudEventRWException if something goes wrong while resolving the {@link SpecVersion} or if the message has an unknown encoding.
+     */
+    public static MessageReader createReader(final org.eclipse.paho.client.mqttv3.MqttMessage message) {
+        return createReader(MqttVersion.MQTTV3, null, null, message.getPayload());
+    }
+
+    /**
+     * Creates a {@link MessageReader} capable of translating an MQTT message to a CloudEvent.
+     * <p>
+     * The MessageReader is constructed as follows:
+     * <ul>
+     * <li>If the mqttVersion corresponds to the MQTT version 3 protocol, a MessageReader capable of reading
+     * <b>only a Structured</b> CloudEvent is returned.</li>
+     * <li>If the mqttVersion corresponds to the MQTT version 5 protocol, a MessageReader capable of reading
+     * <b>both a Structured and Binary</b> CloudEvent is returned.</li>
+     * </ul>
+     *
+     * @param  mqttVersion      Either {@link MqttVersion#MQTTV3} or {@link MqttVersion#MQTTV5} to create a message reader based on
+     *                          an MQTT protocol version.
+     * @param  contentType      The content type of the message payload.
+     * @param  userProperties   In the case of {@link MqttVersion#MQTTV5}, the list of User Properties for an MQTT PUBLISH packet.
+     * @param  payload          The payload of the MQTT message. The payload should be encoded according to the specified content type property.
+     * @return                  A new message reader instance.
+     * @throws CloudEventRWException if something goes wrong while resolving the {@link SpecVersion} or if the message has unknown encoding.
+     * @throws NullPointerException if the mqttVersion is {@code null}.
+     */
+    public static MessageReader createReader(final MqttVersion mqttVersion, final String contentType,
+            final List<UserProperty> userProperties, final byte[] payload) throws CloudEventRWException {
+
+        Objects.requireNonNull(mqttVersion, "MQTT Version must not be null");
+        return mqttVersion.createReader(contentType, userProperties, payload);
+    }
+}

--- a/mqtt/paho/src/main/java/io/cloudevents/mqtt/MqttUtils.java
+++ b/mqtt/paho/src/main/java/io/cloudevents/mqtt/MqttUtils.java
@@ -1,0 +1,27 @@
+package io.cloudevents.mqtt;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+
+public class MqttUtils {
+
+    /**
+     * Gets the value of the user property matching the given property name.
+     *
+     * @param props The list of user properties.
+     * @param name  The name of the user property to retrieve the value for.
+     * @return      The value of the user property matching the given name.
+     */
+    public static String getUserPropertyValue(final List<UserProperty> props, final String name) {
+        if (props == null) {
+            return null;
+        } else {
+            final UserProperty prop = props.stream()
+            .filter(property -> Objects.equals(property.getKey(), name))
+            .findFirst().orElse(null);
+            return prop != null ? prop.getValue() : null;
+        }
+    }
+}

--- a/mqtt/paho/src/main/java/io/cloudevents/mqtt/MqttVersion.java
+++ b/mqtt/paho/src/main/java/io/cloudevents/mqtt/MqttVersion.java
@@ -1,0 +1,52 @@
+package io.cloudevents.mqtt;
+
+import java.util.List;
+
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+
+import io.cloudevents.core.format.EventFormat;
+import io.cloudevents.core.message.MessageReader;
+import io.cloudevents.core.message.impl.GenericStructuredMessageReader;
+import io.cloudevents.core.message.impl.MessageUtils;
+import io.cloudevents.core.provider.EventFormatProvider;
+import io.cloudevents.core.v1.CloudEventV1;
+
+/**
+ * Enumeration of the various MQTT versions specified in the <a href="https://github.com/cloudevents/spec/blob/master/mqtt-protocol-binding.md#3-mqtt-publish-message-mapping">MQTT protocol binding</a>
+ * specification.
+ */
+public enum MqttVersion {
+    MQTTV3 {
+        @Override
+        MessageReader createReader(final String contentType, final List<UserProperty> userProperties, final byte[] payload) {
+
+            // The spec mandates the JSON event format for MQTTv3.
+            // Regardless of the content-type, this method will always succeed in creating a MessageReader.
+            // However, when the event payload is not a JSON formatted payload, an attempt by a client to use the created
+            // reader to read a CloudEvent will result in an EventDeserializationException exception thrown during deserialization.
+            final EventFormat jsonFormat = EventFormatProvider.getInstance().resolveFormat("application/cloudevents+json");
+            return new GenericStructuredMessageReader(jsonFormat, payload);
+        }
+    },
+    MQTTV5 {
+        @Override
+        MessageReader createReader(final String contentType, final List<UserProperty> userProperties, final byte[] payload) {
+            return MessageUtils.parseStructuredOrBinaryMessage(
+                    () -> contentType, 
+                    format -> new GenericStructuredMessageReader(format, payload),
+                    () -> MqttUtils.getUserPropertyValue(userProperties, CloudEventV1.SPECVERSION),
+                    sv -> new PahoMqttBinaryMessageReader(sv, userProperties, contentType, payload));
+        }
+    };
+
+    /**
+     * Creates a new {@link MessageReader} instance that can translate an MQTT message to a CloudEvent.
+     * 
+     * @param contentType       The content type.
+     * @param userProperties    A list of user properties for MQTTv5 or {@code null} for MQTTv3.
+     * @param payload           The payload of the MQTT message.
+     * @return                  An instance of a MessageReader.
+     */
+    abstract MessageReader createReader(final String contentType, final List<UserProperty> userProperties, final byte[] payload);
+}
+

--- a/mqtt/paho/src/main/java/io/cloudevents/mqtt/PahoMqttBinaryMessageReader.java
+++ b/mqtt/paho/src/main/java/io/cloudevents/mqtt/PahoMqttBinaryMessageReader.java
@@ -1,0 +1,75 @@
+package io.cloudevents.mqtt;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.data.BytesCloudEventData;
+import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
+
+/**
+ * An MQTT implementation of the {@link io.cloudevents.core.message.MessageReader} interface based on the Eclipse Paho MQTT client library.
+ * <p>
+ * This reader reads sections of an MQTT message to construct a CloudEvent representation by doing the following:
+ * <ul>
+ *    <li> If the content-type property is set, the value of the property is represented as a cloud event datacontenttype attribute.
+ *    <li> If the (mandatory) user properties contains cloud event attributes (and possibly extensions),
+ *         this reader will represent each attribute as a cloud event attribute and each.
+ * </ul>
+ */
+public class PahoMqttBinaryMessageReader extends BaseGenericBinaryMessageReaderImpl<String, Object> {
+
+    private final String contentType;
+    private final List<UserProperty> userProperties;
+
+    /**
+     * Creates an instance of an MQTTv5 message reader.
+     * 
+     * @param version           The version of the cloud event message.
+     * @param userProperties    The user properties of the MQTTv5 message that contains
+     *                          the cloud event metadata (i.e attributes and extensions).
+     * @param contentType       The content-type property of the message or {@code null} if the content-type is unknown.
+     * @param body              The message payload or {@code null} if the message does not contain any payload.
+     * 
+     * @throws NullPointerException if the user properties is {@code null}.
+     */
+    public PahoMqttBinaryMessageReader(final SpecVersion version, final List<UserProperty> userProperties, final String contentType, final byte[] body) {
+        super(version, body != null && body.length > 0 ? BytesCloudEventData.wrap(body) : null);
+        this.contentType = contentType;
+        this.userProperties = Objects.requireNonNull(userProperties);
+    }
+
+    @Override
+    protected boolean isContentTypeHeader(final String key) {
+        return key.equals("Content Type");
+    }
+
+    @Override
+    protected boolean isCloudEventsHeader(final String key) {
+        // MQTT binding does not mandate a prefix for attribute names
+        return key != null;
+    }
+
+    @Override
+    protected String toCloudEventsKey(final String key) {
+        return key;
+    }
+
+    @Override
+    protected void forEachHeader(final BiConsumer<String, Object> fn) {
+        if (contentType != null) {
+            fn.accept("Content Type", contentType);
+        }
+        userProperties.forEach(property -> {
+            fn.accept(property.getKey(), property.getValue());
+        });
+    }
+
+    @Override
+    protected String toCloudEventsValue(final Object value) {
+        return value.toString();
+    }
+}

--- a/mqtt/paho/src/test/java/io/cloudevents/mqtt/PahoMqttMessageFactoryTest.java
+++ b/mqtt/paho/src/test/java/io/cloudevents/mqtt/PahoMqttMessageFactoryTest.java
@@ -1,0 +1,309 @@
+package io.cloudevents.mqtt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.assertj.core.util.Arrays;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.data.BytesCloudEventData;
+import io.cloudevents.core.format.EventDeserializationException;
+import io.cloudevents.core.message.Encoding;
+import io.cloudevents.core.message.MessageReader;
+import io.cloudevents.core.mock.CSVFormat;
+import io.cloudevents.core.test.Data;
+import io.cloudevents.core.v03.CloudEventV03;
+import io.cloudevents.core.v1.CloudEventV1;
+import io.cloudevents.jackson.JsonFormat;
+import io.cloudevents.types.Time;
+
+/**
+ * Tests verifying the behavior of <em>MqttMessageFactory</em>.
+ */
+public class PahoMqttMessageFactoryTest {
+
+    private static final String DATACONTENTTYPE_NULL = null;
+    /*
+     * The Paho MQTT client library throws a NullpointerException when
+     * the message payload is null. As a workaround, we pass in an empty message payload
+     * instead of null.
+     */
+    private static final byte[] DATAPAYLOAD_EMPTY = "".getBytes();
+
+    /**
+     * Verifies that an MQTTv5 message can be successfully read as a CloudEvent in Binary mode.
+     * 
+     * @param event     The expected CloudEvent message.
+     * @param message   The MQTTv5 message to be read as a CloudEvent.
+     */
+    @ParameterizedTest()
+    @MethodSource("binaryTestArguments")
+    public void testReadBinaryMQTTv5(final CloudEvent event, final MqttMessage message) {     
+        // GIVEN an MQTTv5 message passed as argument
+
+        // WHEN a message reader is created for the MQTT message
+        final MessageReader mqttReader = MqttMessageFactory.createReader(message);
+
+        assertThat(mqttReader.getEncoding()).isEqualTo(Encoding.BINARY);
+        assertThat(mqttReader.toEvent()).isEqualTo(event);
+    }
+
+    /**
+     * Verifies that an MQTTv5 message can be successfully read as a CloudEvent in Structured mode.
+     * 
+     * @param event   The expected CloudEvent message.
+     */
+    @ParameterizedTest()
+    @MethodSource("io.cloudevents.core.test.Data#allEventsWithoutExtensions")
+    public void readStructuredMQTTv5(final CloudEvent event) {
+        // GIVEN an MQTTv5 message containing a CSV formatted payload.
+        final CSVFormat format = new CSVFormat();
+        final String contentType = format.serializedContentType() + "; charset=UTF-8";
+        final byte[] payload =  format.serialize(event);
+
+        // WHEN a message reader is created for the MQTT message
+        final MessageReader mqttReader = MqttMessageFactory.createReader(MqttVersion.MQTTV5, contentType, null, payload);
+
+        // THEN the reader's encoding mode for a CSV format is STRUCTURED
+        assertThat(mqttReader.getEncoding()).isEqualTo(Encoding.STRUCTURED);
+        assertThat(mqttReader.toEvent()).isEqualTo(event);
+    }
+
+    /**
+     * 
+     * @param event   The expected CloudEvent message.
+     */
+    @ParameterizedTest()
+    @MethodSource("io.cloudevents.core.test.Data#allEventsWithoutExtensions")
+    public void readStructuredMQTTv3(final CloudEvent event) {
+        // GIVEN an MQTTv3 message containing a JSON formatted event payload
+        final JsonFormat eventFormat = new JsonFormat();
+        final byte[] payload =  eventFormat.serialize(event);
+        final org.eclipse.paho.client.mqttv3.MqttMessage message = new org.eclipse.paho.client.mqttv3.MqttMessage(payload);
+
+        // WHEN a message reader is created for the MQTT message
+        final MessageReader mqttReader = MqttMessageFactory.createReader(message);
+
+        // THEN  (1) the reader's encoding mode is STRUCTURED
+        assertThat(mqttReader.getEncoding()).isEqualTo(Encoding.STRUCTURED); // content-mode is always structured
+        //       (2) and can translate the mqtt message to a structured CloudEvent
+        assertThat(mqttReader.toEvent(inputData -> BytesCloudEventData.wrap(inputData.toBytes()))).isEqualTo(event);
+    }
+
+    /**
+     * Verifies that an attempt to read a CloudEvent message using an MQTTv3 MessageReader 
+     * created with a CSV event format and payload fails with an <em>EventDeserializationException</em> exception.
+     */
+    @Test
+    public void testReadingCloudEventFailsDeserializationExceptionMqttV3MessageReader() {
+        // GIVEN an MQTTv3 message reader created with a CSV formatted payload
+        final String contentType = "application/cloudevents+csv";
+        final byte[] csvPayload = "a,b,c,d".getBytes();
+        final MessageReader mqttV3Reader = MqttMessageFactory.createReader(MqttVersion.MQTTV3, contentType, null, csvPayload);
+        assertThat(mqttV3Reader.getEncoding()).isEqualTo(Encoding.STRUCTURED);
+
+        // WHEN the reader reads a CloudEvent message
+        assertThrows(EventDeserializationException.class, () -> {
+            // THEN the reader fails with an EventDeserializationException exception.
+            mqttV3Reader.toEvent();
+        });
+    }
+
+    //------------------------<  private methods  >---
+    
+    private static Stream<Arguments> binaryTestArguments() {
+        // V03
+        return Stream.of(
+                Arguments.of(
+                        Data.V03_MIN,
+                         message(
+                             DATAPAYLOAD_EMPTY,
+                             properties(
+                                 DATACONTENTTYPE_NULL,
+                                 new UserProperty(CloudEventV03.SPECVERSION, SpecVersion.V03.toString()),
+                                 new UserProperty(CloudEventV03.ID, Data.ID),
+                                 new UserProperty(CloudEventV03.TYPE, Data.TYPE),
+                                 new UserProperty(CloudEventV03.SOURCE, Data.SOURCE.toString())                             
+                             )
+                         )
+                ),
+                Arguments.of(
+                        Data.V03_WITH_JSON_DATA,
+                         message(
+                             Data.DATA_JSON_SERIALIZED,
+                             properties(
+                                 Data.DATACONTENTTYPE_JSON,
+                                 new UserProperty(CloudEventV03.SPECVERSION, SpecVersion.V03.toString()),
+                                 new UserProperty(CloudEventV03.ID, Data.ID),
+                                 new UserProperty(CloudEventV03.TYPE, Data.TYPE),
+                                 new UserProperty(CloudEventV03.SOURCE, Data.SOURCE.toString()),
+                                 new UserProperty(CloudEventV03.SCHEMAURL, Data.DATASCHEMA.toString()),
+                                 new UserProperty(CloudEventV03.SUBJECT, Data.SUBJECT),
+                                 new UserProperty(CloudEventV03.TIME, Time.writeTime(Data.TIME))
+                             )
+                         )
+                ),
+                Arguments.of(
+                        Data.V03_WITH_JSON_DATA_WITH_EXT_STRING,
+                         message(
+                             Data.DATA_JSON_SERIALIZED,
+                             properties(
+                                 Data.DATACONTENTTYPE_JSON,
+                                 new UserProperty(CloudEventV03.SPECVERSION, SpecVersion.V03.toString()),
+                                 new UserProperty(CloudEventV03.ID, Data.ID),
+                                 new UserProperty(CloudEventV03.TYPE, Data.TYPE),
+                                 new UserProperty(CloudEventV03.SOURCE, Data.SOURCE.toString()),
+                                 new UserProperty(CloudEventV03.SCHEMAURL, Data.DATASCHEMA.toString()),
+                                 new UserProperty(CloudEventV03.SUBJECT, Data.SUBJECT),
+                                 new UserProperty(CloudEventV03.TIME, Time.writeTime(Data.TIME)),
+                                 new UserProperty("astring", "aaa"),
+                                 new UserProperty("aboolean", "true"),
+                                 new UserProperty("anumber", "10")
+                             )
+                         )
+                ),
+                Arguments.of(
+                        Data.V03_WITH_XML_DATA,
+                         message(
+                             Data.DATA_XML_SERIALIZED,
+                             properties(
+                                 Data.DATACONTENTTYPE_XML,
+                                 new UserProperty(CloudEventV03.SPECVERSION, SpecVersion.V03.toString()),
+                                 new UserProperty(CloudEventV03.ID, Data.ID),
+                                 new UserProperty(CloudEventV03.TYPE, Data.TYPE),
+                                 new UserProperty(CloudEventV03.SOURCE, Data.SOURCE.toString()),
+                                 new UserProperty(CloudEventV03.SUBJECT, Data.SUBJECT),
+                                 new UserProperty(CloudEventV03.TIME, Time.writeTime(Data.TIME))
+                             )
+                         )
+                ),
+                Arguments.of(
+                        Data.V03_WITH_TEXT_DATA,
+                         message(
+                             Data.DATA_TEXT_SERIALIZED,
+                             properties(
+                                 Data.DATACONTENTTYPE_TEXT,
+                                 new UserProperty(CloudEventV03.SPECVERSION, SpecVersion.V03.toString()),
+                                 new UserProperty(CloudEventV03.ID, Data.ID),
+                                 new UserProperty(CloudEventV03.TYPE, Data.TYPE),
+                                 new UserProperty(CloudEventV03.SOURCE, Data.SOURCE.toString()),
+                                 new UserProperty(CloudEventV03.SUBJECT, Data.SUBJECT),
+                                 new UserProperty(CloudEventV03.TIME, Time.writeTime(Data.TIME))
+                             )
+                         )
+                ),
+                // V1
+                Arguments.of(
+                       Data.V1_MIN,
+                        message(
+                            DATAPAYLOAD_EMPTY,
+                            properties(
+                                DATACONTENTTYPE_NULL,
+                                new UserProperty(CloudEventV1.SPECVERSION, SpecVersion.V1.toString()),
+                                new UserProperty(CloudEventV1.ID, Data.ID),
+                                new UserProperty(CloudEventV1.TYPE, Data.TYPE),
+                                new UserProperty(CloudEventV1.SOURCE, Data.SOURCE.toString())
+                            )
+                        )
+                ),
+                Arguments.of(
+                        Data.V1_WITH_JSON_DATA,
+                        message(
+                            Data.DATA_JSON_SERIALIZED,
+                            properties(
+                                Data.DATACONTENTTYPE_JSON,
+                                new UserProperty(CloudEventV1.SPECVERSION, SpecVersion.V1.toString()),
+                                new UserProperty(CloudEventV1.ID, Data.ID),
+                                new UserProperty(CloudEventV1.TYPE, Data.TYPE),
+                                new UserProperty(CloudEventV1.SOURCE, Data.SOURCE.toString()),
+                                new UserProperty(CloudEventV1.DATASCHEMA, Data.DATASCHEMA.toString()),
+                                new UserProperty(CloudEventV1.SUBJECT, Data.SUBJECT),
+                                new UserProperty(CloudEventV1.TIME, Time.writeTime(Data.TIME))
+                            )
+                        )
+                ),
+                Arguments.of(
+                        Data.V1_WITH_JSON_DATA_WITH_EXT_STRING,
+                        message(
+                            Data.DATA_JSON_SERIALIZED,
+                            properties(
+                                Data.DATACONTENTTYPE_JSON,
+                                new UserProperty(CloudEventV1.SPECVERSION, SpecVersion.V1.toString()),
+                                new UserProperty(CloudEventV1.ID, Data.ID),
+                                new UserProperty(CloudEventV1.TYPE, Data.TYPE),
+                                new UserProperty(CloudEventV1.SOURCE, Data.SOURCE.toString()),
+                                new UserProperty(CloudEventV1.SUBJECT, Data.SUBJECT),
+                                new UserProperty(CloudEventV1.DATASCHEMA, Data.DATASCHEMA.toString()),
+                                new UserProperty(CloudEventV1.TIME, Time.writeTime(Data.TIME)),
+                                new UserProperty("astring", "aaa"),
+                                new UserProperty("aboolean", "true"),
+                                new UserProperty("anumber", "10")
+                            )
+                        )
+                ),
+                Arguments.of(
+                        Data.V1_WITH_XML_DATA,
+                        message(
+                            Data.DATA_XML_SERIALIZED,
+                            properties(
+                                Data.DATACONTENTTYPE_XML,
+                                new UserProperty(CloudEventV1.SPECVERSION, SpecVersion.V1.toString()),
+                                new UserProperty(CloudEventV1.ID, Data.ID),
+                                new UserProperty(CloudEventV1.TYPE, Data.TYPE),
+                                new UserProperty(CloudEventV1.SOURCE, Data.SOURCE.toString()),
+                                new UserProperty(CloudEventV1.SUBJECT, Data.SUBJECT),
+                                new UserProperty(CloudEventV1.TIME, Time.writeTime(Data.TIME))
+                            )
+                        )
+                ),
+                Arguments.of(
+                        Data.V1_WITH_TEXT_DATA,
+                        message(
+                            Data.DATA_TEXT_SERIALIZED,
+                            properties(
+                                Data.DATACONTENTTYPE_TEXT,
+                                new UserProperty(CloudEventV1.SPECVERSION, SpecVersion.V1.toString()),
+                                new UserProperty(CloudEventV1.ID, Data.ID),
+                                new UserProperty(CloudEventV1.TYPE, Data.TYPE),
+                                new UserProperty(CloudEventV1.SOURCE, Data.SOURCE.toString()),
+                                new UserProperty(CloudEventV1.SUBJECT, Data.SUBJECT),
+                                new UserProperty(CloudEventV1.TIME, Time.writeTime(Data.TIME))
+                            )
+                        )
+                )
+        );
+        
+        
+    }
+
+    private static final MqttMessage message(final byte[] payload, final MqttProperties properties) {
+        final MqttMessage message = new MqttMessage(payload);
+        message.setProperties(properties);
+        return message;
+    }
+
+    private static final MqttProperties properties(final String contentType, final UserProperty... userProperties) {
+        final MqttProperties properties = new MqttProperties();
+        properties.setContentType(contentType);
+        properties.setUserProperties(
+                    Arrays.asList(userProperties)
+                    .stream()
+                    .map(property -> (UserProperty) property)
+                    .collect(Collectors.toList())
+                );
+        return properties;
+
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <module>http/restful-ws</module>
         <module>kafka</module>
         <module>spring</module>
+        <module>mqtt/paho</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
A first patch that implements the `MessageReader` for #335 

**TODO**: implement the MessageWriter for MqttV3 and MqttV5 clients. 

@slinkydeveloper any feedback is welcome, while i work on implementing the MessageWriter interface

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>