### PR TITLE
Update the link to http4k Cloud Events module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ for how PR reviews and approval, and our
 [Code of Conduct](https://github.com/cloudevents/spec/blob/master/community/GOVERNANCE.md#additional-information)
 information.
 
-[http4k]: https://www.http4k.org/guide/modules/cloud_events/
+[http4k]: https://www.http4k.org/guide/reference/cloud_events/


### PR DESCRIPTION
The guide site of http4k has been updated.

![Screenshot from 2021-05-26 13-57-39](https://user-images.githubusercontent.com/638068/119609569-64901480-be2a-11eb-8b75-2b0c627cea37.png)
