### PR TITLE
[CESQL] Simpler interface to perform casting

### DIFF
--- a/sql/src/main/java/io/cloudevents/sql/EvaluationRuntime.java
+++ b/sql/src/main/java/io/cloudevents/sql/EvaluationRuntime.java
@@ -28,6 +28,15 @@ public interface EvaluationRuntime {
     Object cast(EvaluationContext ctx, Object value, Type target);
 
     /**
+     * Return the {@code value} casted to the {@code target} type. If fails, this is going to throw an exception without the evaluation context.
+     *
+     * @param value  the value to cast
+     * @param target the type cast target
+     * @return the casted value, if the cast succeeds, otherwise the default value of the target type
+     */
+    Object cast(Object value, Type target) throws EvaluationException;
+
+    /**
      * Resolve a {@link Function} starting from its name and the concrete number of arguments.
      *
      * @param name the name of the function

--- a/sql/src/main/java/io/cloudevents/sql/impl/EvaluationRuntimeImpl.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/EvaluationRuntimeImpl.java
@@ -1,9 +1,6 @@
 package io.cloudevents.sql.impl;
 
-import io.cloudevents.sql.EvaluationContext;
-import io.cloudevents.sql.EvaluationRuntime;
-import io.cloudevents.sql.Function;
-import io.cloudevents.sql.Type;
+import io.cloudevents.sql.*;
 
 public class EvaluationRuntimeImpl implements EvaluationRuntime {
 
@@ -34,6 +31,11 @@ public class EvaluationRuntimeImpl implements EvaluationRuntime {
     @Override
     public Object cast(EvaluationContext ctx, Object value, Type target) {
         return this.typeCastingProvider.cast(ctx, value, target);
+    }
+
+    @Override
+    public Object cast(Object value, Type target) throws EvaluationException {
+        return this.typeCastingProvider.cast(FailFastExceptionThrower.getInstance(), value, target);
     }
 
     @Override

--- a/sql/src/main/java/io/cloudevents/sql/impl/FailFastExceptionThrower.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/FailFastExceptionThrower.java
@@ -1,8 +1,10 @@
 package io.cloudevents.sql.impl;
 
+import io.cloudevents.sql.EvaluationContext;
 import io.cloudevents.sql.EvaluationException;
+import org.antlr.v4.runtime.misc.Interval;
 
-class FailFastExceptionThrower implements ExceptionThrower {
+class FailFastExceptionThrower implements ExceptionThrower, EvaluationContext {
 
     private static class SingletonContainer {
         private final static FailFastExceptionThrower INSTANCE = new FailFastExceptionThrower();
@@ -15,5 +17,25 @@ class FailFastExceptionThrower implements ExceptionThrower {
     @Override
     public void throwException(EvaluationException exception) {
         throw exception;
+    }
+
+    @Override
+    public Interval expressionInterval() {
+        return Interval.INVALID;
+    }
+
+    @Override
+    public String expressionText() {
+        return "";
+    }
+
+    @Override
+    public void appendException(EvaluationException exception) {
+        throwException(exception);
+    }
+
+    @Override
+    public void appendException(EvaluationException.EvaluationExceptionFactory exceptionFactory) {
+        throwException(exceptionFactory.create(expressionInterval(), expressionText()));
     }
 }

--- a/sql/src/test/java/io/cloudevents/sql/impl/EvaluationRuntimeImplTest.java
+++ b/sql/src/test/java/io/cloudevents/sql/impl/EvaluationRuntimeImplTest.java
@@ -1,0 +1,25 @@
+package io.cloudevents.sql.impl;
+
+import io.cloudevents.sql.EvaluationException;
+import io.cloudevents.sql.EvaluationRuntime;
+import io.cloudevents.sql.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class EvaluationRuntimeImplTest {
+
+    @Test
+    void castingFails() {
+        assertThatCode(() -> EvaluationRuntime.getDefault().cast("123", Type.BOOLEAN))
+            .isInstanceOf(EvaluationException.class);
+    }
+
+    @Test
+    void castingSucceeds() {
+        assertThat(EvaluationRuntime.getDefault().cast("TRUE", Type.BOOLEAN))
+            .isEqualTo(true);
+    }
+
+}


### PR DESCRIPTION
Provide a simpler interface to perform casting outside an expression. This is useful when the output result of the expression needs to be coerced to a specific type, eg when using for filtering, you always need to coerce the result back to boolean.

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>