### PR TITLE
[CESQL] Reorganize package implementation classes

### DIFF
--- a/sql/src/main/java/io/cloudevents/sql/EvaluationRuntime.java
+++ b/sql/src/main/java/io/cloudevents/sql/EvaluationRuntime.java
@@ -1,7 +1,7 @@
 package io.cloudevents.sql;
 
-import io.cloudevents.sql.impl.EvaluationRuntimeBuilder;
-import io.cloudevents.sql.impl.EvaluationRuntimeImpl;
+import io.cloudevents.sql.impl.runtime.EvaluationRuntimeBuilder;
+import io.cloudevents.sql.impl.runtime.EvaluationRuntimeImpl;
 
 /**
  * The evaluation runtime takes care of the function resolution, casting and other core functionalities to execute an expression.

--- a/sql/src/main/java/io/cloudevents/sql/Parser.java
+++ b/sql/src/main/java/io/cloudevents/sql/Parser.java
@@ -1,7 +1,7 @@
 package io.cloudevents.sql;
 
-import io.cloudevents.sql.impl.ParserBuilder;
-import io.cloudevents.sql.impl.ParserImpl;
+import io.cloudevents.sql.impl.parser.ParserBuilder;
+import io.cloudevents.sql.impl.parser.ParserImpl;
 
 public interface Parser {
 

--- a/sql/src/main/java/io/cloudevents/sql/impl/ExpressionInternal.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/ExpressionInternal.java
@@ -1,8 +1,7 @@
-package io.cloudevents.sql.impl.expressions;
+package io.cloudevents.sql.impl;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.sql.EvaluationRuntime;
-import io.cloudevents.sql.impl.ExceptionThrower;
 import org.antlr.v4.runtime.misc.Interval;
 
 public interface ExpressionInternal {

--- a/sql/src/main/java/io/cloudevents/sql/impl/ExpressionInternalVisitor.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/ExpressionInternalVisitor.java
@@ -1,4 +1,6 @@
-package io.cloudevents.sql.impl.expressions;
+package io.cloudevents.sql.impl;
+
+import io.cloudevents.sql.impl.expressions.*;
 
 public interface ExpressionInternalVisitor<T> {
 

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/AccessAttributeExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/AccessAttributeExpression.java
@@ -6,7 +6,6 @@ import io.cloudevents.sql.EvaluationException;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
 import io.cloudevents.sql.impl.ExpressionInternalVisitor;
-import io.cloudevents.sql.impl.runtime.CloudEventUtils;
 import org.antlr.v4.runtime.misc.Interval;
 
 import java.util.Base64;

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/AccessAttributeExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/AccessAttributeExpression.java
@@ -5,6 +5,8 @@ import io.cloudevents.SpecVersion;
 import io.cloudevents.sql.EvaluationException;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternalVisitor;
+import io.cloudevents.sql.impl.runtime.CloudEventUtils;
 import org.antlr.v4.runtime.misc.Interval;
 
 import java.util.Base64;

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/AndExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/AndExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class AndExpression extends BaseBinaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/BaseBinaryExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/BaseBinaryExpression.java
@@ -3,6 +3,8 @@ package io.cloudevents.sql.impl.expressions;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
+import io.cloudevents.sql.impl.ExpressionInternalVisitor;
 import org.antlr.v4.runtime.misc.Interval;
 
 public abstract class BaseBinaryExpression extends BaseExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/BaseExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/BaseExpression.java
@@ -2,8 +2,9 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.Type;
-import io.cloudevents.sql.impl.EvaluationContextImpl;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
+import io.cloudevents.sql.impl.runtime.EvaluationContextImpl;
 import org.antlr.v4.runtime.misc.Interval;
 
 public abstract class BaseExpression implements ExpressionInternal {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/BaseIntegerBinaryExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/BaseIntegerBinaryExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public abstract class BaseIntegerBinaryExpression extends BaseBinaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/BaseUnaryExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/BaseUnaryExpression.java
@@ -3,6 +3,8 @@ package io.cloudevents.sql.impl.expressions;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
+import io.cloudevents.sql.impl.ExpressionInternalVisitor;
 import org.antlr.v4.runtime.misc.Interval;
 
 public abstract class BaseUnaryExpression extends BaseExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/DifferenceExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/DifferenceExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class DifferenceExpression extends BaseIntegerBinaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/DivisionExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/DivisionExpression.java
@@ -3,6 +3,7 @@ package io.cloudevents.sql.impl.expressions;
 import io.cloudevents.sql.EvaluationException;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class DivisionExpression extends BaseIntegerBinaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/EqualExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/EqualExpression.java
@@ -2,8 +2,9 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.Type;
-import io.cloudevents.sql.impl.EvaluationContextImpl;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
+import io.cloudevents.sql.impl.runtime.EvaluationContextImpl;
 import org.antlr.v4.runtime.misc.Interval;
 
 import java.util.Objects;

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/ExistsExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/ExistsExpression.java
@@ -3,6 +3,8 @@ package io.cloudevents.sql.impl.expressions;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternalVisitor;
+import io.cloudevents.sql.impl.runtime.CloudEventUtils;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class ExistsExpression extends BaseExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/ExistsExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/ExistsExpression.java
@@ -4,7 +4,6 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
 import io.cloudevents.sql.impl.ExpressionInternalVisitor;
-import io.cloudevents.sql.impl.runtime.CloudEventUtils;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class ExistsExpression extends BaseExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/FunctionInvocationExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/FunctionInvocationExpression.java
@@ -5,8 +5,10 @@ import io.cloudevents.sql.EvaluationContext;
 import io.cloudevents.sql.EvaluationException;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.Function;
-import io.cloudevents.sql.impl.EvaluationContextImpl;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
+import io.cloudevents.sql.impl.ExpressionInternalVisitor;
+import io.cloudevents.sql.impl.runtime.EvaluationContextImpl;
 import org.antlr.v4.runtime.misc.Interval;
 
 import java.util.ArrayList;

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/InExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/InExpression.java
@@ -3,8 +3,10 @@ package io.cloudevents.sql.impl.expressions;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.Type;
-import io.cloudevents.sql.impl.EvaluationContextImpl;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
+import io.cloudevents.sql.impl.ExpressionInternalVisitor;
+import io.cloudevents.sql.impl.runtime.EvaluationContextImpl;
 import org.antlr.v4.runtime.misc.Interval;
 
 import java.util.List;

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/IntegerComparisonBinaryExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/IntegerComparisonBinaryExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 import java.util.function.BiFunction;

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/LikeExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/LikeExpression.java
@@ -3,6 +3,8 @@ package io.cloudevents.sql.impl.expressions;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
+import io.cloudevents.sql.impl.ExpressionInternalVisitor;
 import org.antlr.v4.runtime.misc.Interval;
 
 import java.util.regex.Pattern;

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/ModuleExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/ModuleExpression.java
@@ -3,6 +3,7 @@ package io.cloudevents.sql.impl.expressions;
 import io.cloudevents.sql.EvaluationException;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class ModuleExpression extends BaseIntegerBinaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/MultiplicationExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/MultiplicationExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class MultiplicationExpression extends BaseIntegerBinaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/NegateExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/NegateExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class NegateExpression extends BaseUnaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/NotExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/NotExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class NotExpression extends BaseUnaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/OrExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/OrExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class OrExpression extends BaseBinaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/SumExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/SumExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class SumExpression extends BaseIntegerBinaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/ValueExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/ValueExpression.java
@@ -3,7 +3,8 @@ package io.cloudevents.sql.impl.expressions;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
-import io.cloudevents.sql.impl.LiteralUtils;
+import io.cloudevents.sql.impl.ExpressionInternalVisitor;
+import io.cloudevents.sql.impl.parser.LiteralUtils;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.TerminalNode;
 

--- a/sql/src/main/java/io/cloudevents/sql/impl/expressions/XorExpression.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/expressions/XorExpression.java
@@ -2,6 +2,7 @@ package io.cloudevents.sql.impl.expressions;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.impl.ExceptionThrower;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class XorExpression extends BaseBinaryExpression {

--- a/sql/src/main/java/io/cloudevents/sql/impl/parser/CaseChangingCharStream.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/parser/CaseChangingCharStream.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.parser;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.misc.Interval;

--- a/sql/src/main/java/io/cloudevents/sql/impl/parser/ConstantFoldingExpressionVisitor.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/parser/ConstantFoldingExpressionVisitor.java
@@ -1,8 +1,14 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.parser;
 
 import io.cloudevents.SpecVersion;
 import io.cloudevents.sql.EvaluationRuntime;
-import io.cloudevents.sql.impl.expressions.*;
+import io.cloudevents.sql.impl.ExpressionInternal;
+import io.cloudevents.sql.impl.ExpressionInternalVisitor;
+import io.cloudevents.sql.impl.expressions.BaseBinaryExpression;
+import io.cloudevents.sql.impl.expressions.BaseUnaryExpression;
+import io.cloudevents.sql.impl.expressions.ExistsExpression;
+import io.cloudevents.sql.impl.expressions.ValueExpression;
+import io.cloudevents.sql.impl.runtime.FailFastExceptionThrower;
 
 public class ConstantFoldingExpressionVisitor implements ExpressionInternalVisitor<ExpressionInternal> {
 

--- a/sql/src/main/java/io/cloudevents/sql/impl/parser/ExpressionTranslatorVisitor.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/parser/ExpressionTranslatorVisitor.java
@@ -1,9 +1,10 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.parser;
 
 import io.cloudevents.sql.ParseException;
 import io.cloudevents.sql.Type;
 import io.cloudevents.sql.generated.CESQLParserBaseVisitor;
 import io.cloudevents.sql.generated.CESQLParserParser;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import io.cloudevents.sql.impl.expressions.*;
 
 import java.util.List;

--- a/sql/src/main/java/io/cloudevents/sql/impl/parser/LiteralUtils.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/parser/LiteralUtils.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.parser;
 
 import org.antlr.v4.runtime.tree.TerminalNode;
 

--- a/sql/src/main/java/io/cloudevents/sql/impl/parser/ParserBuilder.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/parser/ParserBuilder.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.parser;
 
 import io.cloudevents.sql.Parser;
 

--- a/sql/src/main/java/io/cloudevents/sql/impl/parser/ParserImpl.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/parser/ParserImpl.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.parser;
 
 import io.cloudevents.sql.EvaluationException;
 import io.cloudevents.sql.Expression;
@@ -6,7 +6,8 @@ import io.cloudevents.sql.ParseException;
 import io.cloudevents.sql.Parser;
 import io.cloudevents.sql.generated.CESQLParserLexer;
 import io.cloudevents.sql.generated.CESQLParserParser;
-import io.cloudevents.sql.impl.expressions.ExpressionInternal;
+import io.cloudevents.sql.impl.ExpressionInternal;
+import io.cloudevents.sql.impl.runtime.ExpressionImpl;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.dfa.DFA;

--- a/sql/src/main/java/io/cloudevents/sql/impl/runtime/EvaluationContextImpl.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/runtime/EvaluationContextImpl.java
@@ -1,7 +1,8 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.sql.EvaluationContext;
 import io.cloudevents.sql.EvaluationException;
+import io.cloudevents.sql.impl.ExceptionThrower;
 import org.antlr.v4.runtime.misc.Interval;
 
 public class EvaluationContextImpl implements EvaluationContext {

--- a/sql/src/main/java/io/cloudevents/sql/impl/runtime/EvaluationResult.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/runtime/EvaluationResult.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.sql.EvaluationException;
 import io.cloudevents.sql.Result;

--- a/sql/src/main/java/io/cloudevents/sql/impl/runtime/EvaluationRuntimeBuilder.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/runtime/EvaluationRuntimeBuilder.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.Function;

--- a/sql/src/main/java/io/cloudevents/sql/impl/runtime/EvaluationRuntimeImpl.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/runtime/EvaluationRuntimeImpl.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.sql.*;
 

--- a/sql/src/main/java/io/cloudevents/sql/impl/runtime/ExceptionStore.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/runtime/ExceptionStore.java
@@ -1,6 +1,7 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.sql.EvaluationException;
+import io.cloudevents.sql.impl.ExceptionThrower;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/sql/src/main/java/io/cloudevents/sql/impl/runtime/ExpressionImpl.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/runtime/ExpressionImpl.java
@@ -1,11 +1,11 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.sql.EvaluationException;
 import io.cloudevents.sql.EvaluationRuntime;
 import io.cloudevents.sql.Expression;
 import io.cloudevents.sql.Result;
-import io.cloudevents.sql.impl.expressions.ExpressionInternal;
+import io.cloudevents.sql.impl.ExpressionInternal;
 
 public class ExpressionImpl implements Expression {
 
@@ -27,7 +27,7 @@ public class ExpressionImpl implements Expression {
         return this.expressionInternal.evaluate(evaluationRuntime, event, FailFastExceptionThrower.getInstance());
     }
 
-    protected ExpressionInternal getExpressionInternal() {
+    public ExpressionInternal getExpressionInternal() {
         return expressionInternal;
     }
 }

--- a/sql/src/main/java/io/cloudevents/sql/impl/runtime/FailFastExceptionThrower.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/runtime/FailFastExceptionThrower.java
@@ -1,16 +1,17 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.sql.EvaluationContext;
 import io.cloudevents.sql.EvaluationException;
+import io.cloudevents.sql.impl.ExceptionThrower;
 import org.antlr.v4.runtime.misc.Interval;
 
-class FailFastExceptionThrower implements ExceptionThrower, EvaluationContext {
+public class FailFastExceptionThrower implements ExceptionThrower, EvaluationContext {
 
     private static class SingletonContainer {
         private final static FailFastExceptionThrower INSTANCE = new FailFastExceptionThrower();
     }
 
-    static FailFastExceptionThrower getInstance() {
+    public static FailFastExceptionThrower getInstance() {
         return FailFastExceptionThrower.SingletonContainer.INSTANCE;
     }
 

--- a/sql/src/main/java/io/cloudevents/sql/impl/runtime/FunctionTable.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/runtime/FunctionTable.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.sql.Function;
 import io.cloudevents.sql.impl.functions.*;

--- a/sql/src/main/java/io/cloudevents/sql/impl/runtime/TypeCastingProvider.java
+++ b/sql/src/main/java/io/cloudevents/sql/impl/runtime/TypeCastingProvider.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.sql.EvaluationContext;
 import io.cloudevents.sql.EvaluationException;

--- a/sql/src/test/java/io/cloudevents/sql/CustomFunctionsTest.java
+++ b/sql/src/test/java/io/cloudevents/sql/CustomFunctionsTest.java
@@ -3,9 +3,9 @@ package io.cloudevents.sql;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.test.Data;
-import io.cloudevents.sql.impl.EvaluationRuntimeBuilder;
 import io.cloudevents.sql.impl.functions.BaseFunction;
 import io.cloudevents.sql.impl.functions.InfallibleOneArgumentFunction;
+import io.cloudevents.sql.impl.runtime.EvaluationRuntimeBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/sql/src/test/java/io/cloudevents/sql/impl/parser/ConstantFoldingTest.java
+++ b/sql/src/test/java/io/cloudevents/sql/impl/parser/ConstantFoldingTest.java
@@ -1,11 +1,12 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.parser;
 
 import io.cloudevents.sql.Expression;
 import io.cloudevents.sql.Parser;
+import io.cloudevents.sql.impl.ExpressionInternal;
 import io.cloudevents.sql.impl.expressions.BaseBinaryExpression;
 import io.cloudevents.sql.impl.expressions.ExistsExpression;
-import io.cloudevents.sql.impl.expressions.ExpressionInternal;
 import io.cloudevents.sql.impl.expressions.ValueExpression;
+import io.cloudevents.sql.impl.runtime.ExpressionImpl;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sql/src/test/java/io/cloudevents/sql/impl/runtime/EvaluationRuntimeImplTest.java
+++ b/sql/src/test/java/io/cloudevents/sql/impl/runtime/EvaluationRuntimeImplTest.java
@@ -1,4 +1,4 @@
-package io.cloudevents.sql.impl;
+package io.cloudevents.sql.impl.runtime;
 
 import io.cloudevents.sql.EvaluationException;
 import io.cloudevents.sql.EvaluationRuntime;


### PR DESCRIPTION
Reorganized the `impl` subpackage in:

* `impl` contains only the internal interfaces
* `impl.parser` for the parsing and optimization related code
* `impl.runtime` for the runtime related code
* `impl.functions` for the built-in function implementations
* `impl.expressions` for the expression implementations

No code was changed, except imports and changing visibility of some methods/classes.

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>