### PR TITLE
Fix the Java Doc build

### DIFF
--- a/api/src/main/java/io/cloudevents/rw/CloudEventReader.java
+++ b/api/src/main/java/io/cloudevents/rw/CloudEventReader.java
@@ -32,7 +32,12 @@ public interface CloudEventReader {
     /**
      * Like {@link #read(CloudEventWriterFactory, CloudEventDataMapper)}, but with the identity {@link CloudEventDataMapper}.
      *
+     * @param <W> The type of the {@link CloudEventWriter} created by writerFactory
+     * @param <R> The return value of the {@link CloudEventWriter} created by writerFactory
+     * @param writerFactory a factory that generates a visitor starting from the SpecVersion of the event
      * @see #read(CloudEventWriterFactory, CloudEventDataMapper)
+     * @return the value returned by {@link CloudEventWriter#end()} or {@link CloudEventWriter#end(CloudEventData)}
+     * @throws CloudEventRWException if something went wrong during the read.
      */
     default <W extends CloudEventWriter<R>, R> R read(CloudEventWriterFactory<W, R> writerFactory) throws CloudEventRWException {
         return read(writerFactory, CloudEventDataMapper.identity());

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,6 @@
                     <detectLinks/>
                     <links>
                         <link>https://docs.spring.io/spring-framework/docs/current/javadoc-api/</link>
-                        <link>https://vertx.io/docs/apidocs/</link>
                         <link>https://jakarta.ee/specifications/platform/8/apidocs/</link>
                         <link>https://kafka.apache.org/25/javadoc/</link>
                         <link>https://qpid.apache.org/releases/qpid-proton-j-0.33.7/api/</link>


### PR DESCRIPTION
- https://vertx.io/docs/apidocs/ returns 404, so removing it
- Fix Java Doc error for missing `@param`