### PR TITLE
Ignore not valid extension name in jackson CloudEventDeserializer

### DIFF
--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -126,7 +126,13 @@ class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
 
                 // Now let's process the extensions
                 node.fields().forEachRemaining(entry -> {
-                    String extensionName = entry.getKey();
+                    String extensionName = entry.getKey().toLowerCase();
+
+                    // ignore not valid extension name
+                    if (!this.isValidExtensionName(extensionName)) {
+                        return;
+                    }
+
                     JsonNode extensionValue = entry.getValue();
 
                     switch (extensionValue.getNodeType()) {
@@ -192,6 +198,27 @@ class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
                 );
             }
         }
+
+        /**
+         * Validates the extension name as defined in  CloudEvents spec.
+         *
+         * @param name the extension name
+         * @return true if extension name is valid, false otherwise
+         * @see <a href="https://github.com/cloudevents/spec/blob/master/spec.md#attribute-naming-convention">attribute-naming-convention</a>
+         */
+        private boolean isValidExtensionName(String name) {
+            for (int i = 0; i < name.length(); i++) {
+                if (!isValidChar(name.charAt(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private boolean isValidChar(char c) {
+            return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+        }
+
     }
 
     @Override

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -41,6 +41,10 @@ class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
     private final boolean forceExtensionNameLowerCaseDeserialization;
     private final boolean forceIgnoreInvalidExtensionNameDeserialization;
 
+    protected CloudEventDeserializer() {
+        this(false, false);
+    }
+
     protected CloudEventDeserializer(
         boolean forceExtensionNameLowerCaseDeserialization,
         boolean forceIgnoreInvalidExtensionNameDeserialization

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormatOptions.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormatOptions.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.cloudevents.jackson;
+
+public final class JsonFormatOptions {
+    private final boolean forceDataBase64Serialization;
+    private final boolean forceStringSerialization;
+    private final boolean forceExtensionNameLowerCaseDeserialization;
+    private final boolean forceIgnoreInvalidExtensionNameDeserialization;
+
+    /**
+     * Create a new instance of this class options the serialization / deserialization.
+     */
+    public JsonFormatOptions() {
+        this(false, false, false, false);
+    }
+
+    JsonFormatOptions(
+        boolean forceDataBase64Serialization,
+        boolean forceStringSerialization,
+        boolean forceExtensionNameLowerCaseDeserialization,
+        boolean forceIgnoreInvalidExtensionNameDeserialization
+    ) {
+        this.forceDataBase64Serialization = forceDataBase64Serialization;
+        this.forceStringSerialization = forceStringSerialization;
+        this.forceExtensionNameLowerCaseDeserialization = forceExtensionNameLowerCaseDeserialization;
+        this.forceIgnoreInvalidExtensionNameDeserialization = forceIgnoreInvalidExtensionNameDeserialization;
+    }
+
+    public static JsonFormatOptionsBuilder builder() {
+        return new JsonFormatOptionsBuilder();
+    }
+
+    public boolean isForceDataBase64Serialization() {
+        return this.forceDataBase64Serialization;
+    }
+
+    public boolean isForceStringSerialization() {
+        return this.forceStringSerialization;
+    }
+
+    public boolean isForceExtensionNameLowerCaseDeserialization() {
+        return this.forceExtensionNameLowerCaseDeserialization;
+    }
+
+    public boolean isForceIgnoreInvalidExtensionNameDeserialization() {
+        return this.forceIgnoreInvalidExtensionNameDeserialization;
+    }
+
+    public static class JsonFormatOptionsBuilder {
+        private boolean forceDataBase64Serialization = false;
+        private boolean forceStringSerialization = false;
+        private boolean forceExtensionNameLowerCaseDeserialization = false;
+        private boolean forceIgnoreInvalidExtensionNameDeserialization = false;
+
+        public JsonFormatOptionsBuilder forceDataBase64Serialization(boolean forceDataBase64Serialization) {
+            this.forceDataBase64Serialization = forceDataBase64Serialization;
+            return this;
+        }
+
+        public JsonFormatOptionsBuilder forceStringSerialization(boolean forceStringSerialization) {
+            this.forceStringSerialization = forceStringSerialization;
+            return this;
+        }
+
+        public JsonFormatOptionsBuilder forceExtensionNameLowerCaseDeserialization(boolean forceExtensionNameLowerCaseDeserialization) {
+            this.forceExtensionNameLowerCaseDeserialization = forceExtensionNameLowerCaseDeserialization;
+            return this;
+        }
+
+        public JsonFormatOptionsBuilder forceIgnoreInvalidExtensionNameDeserialization(boolean forceIgnoreInvalidExtensionNameDeserialization) {
+            this.forceIgnoreInvalidExtensionNameDeserialization = forceIgnoreInvalidExtensionNameDeserialization;
+            return this;
+        }
+
+        public JsonFormatOptions build() {
+            return new JsonFormatOptions(
+                this.forceDataBase64Serialization,
+                this.forceStringSerialization,
+                this.forceExtensionNameLowerCaseDeserialization,
+                this.forceIgnoreInvalidExtensionNameDeserialization
+            );
+        }
+    }
+}

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
@@ -27,14 +27,12 @@ import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.format.EventDeserializationException;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.rw.CloudEventRWException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -86,6 +84,22 @@ class JsonFormatTest {
     @MethodSource("deserializeTestArguments")
     void deserialize(String inputFile, CloudEvent output) {
         CloudEvent deserialized = getFormat().deserialize(loadFile(inputFile));
+        assertThat(deserialized)
+            .isEqualTo(output);
+    }
+
+    @ParameterizedTest
+    @MethodSource("deserializeTestArgumentsUpperCaseExtensionName")
+    void deserializeWithUpperCaseExtensionName(String inputFile, CloudEvent output) {
+        CloudEvent deserialized = getFormat().withForceExtensionNameLowerCaseDeserialization().deserialize(loadFile(inputFile));
+        assertThat(deserialized)
+            .isEqualTo(output);
+    }
+
+    @ParameterizedTest
+    @MethodSource("deserializeTestArgumentsInvalidExtensionName")
+    void deserializeWithInvalidExtensionName(String inputFile, CloudEvent output) {
+        CloudEvent deserialized = getFormat().withForceIgnoreInvalidExtensionNameDeserialization().deserialize(loadFile(inputFile));
         assertThat(deserialized)
             .isEqualTo(output);
     }
@@ -201,6 +215,20 @@ class JsonFormatTest {
             Arguments.of("v1/base64_xml_data.json", V1_WITH_XML_DATA),
             Arguments.of("v1/text_data.json", V1_WITH_TEXT_DATA),
             Arguments.of("v1/base64_text_data.json", V1_WITH_TEXT_DATA)
+        );
+    }
+
+    public static Stream<Arguments> deserializeTestArgumentsUpperCaseExtensionName() {
+        return Stream.of(
+            Arguments.of("v03/json_data_with_ext_upper_case.json", normalizeToJsonValueIfNeeded(V03_WITH_JSON_DATA_WITH_EXT)),
+            Arguments.of("v1/json_data_with_ext_upper_case.json", normalizeToJsonValueIfNeeded(V1_WITH_JSON_DATA_WITH_EXT))
+        );
+    }
+
+    public static Stream<Arguments> deserializeTestArgumentsInvalidExtensionName() {
+        return Stream.of(
+            Arguments.of("v03/json_data_with_ext_invalid.json", normalizeToJsonValueIfNeeded(V03_WITH_JSON_DATA_WITH_EXT)),
+            Arguments.of("v1/json_data_with_ext_invalid.json", normalizeToJsonValueIfNeeded(V1_WITH_JSON_DATA_WITH_EXT))
         );
     }
 

--- a/formats/json-jackson/src/test/resources/v03/json_data_with_ext_invalid.json
+++ b/formats/json-jackson/src/test/resources/v03/json_data_with_ext_invalid.json
@@ -1,0 +1,15 @@
+{
+    "specversion": "0.3",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "schemaurl": "http://localhost/schema",
+    "datacontenttype": "application/json",
+    "data": {},
+    "subject": "sub",
+    "time": "2018-04-26T14:48:09+02:00",
+    "astring": "aaa",
+    "aboolean": true,
+    "anumber": 10,
+    "a_invalid_name": "invalidName"
+}

--- a/formats/json-jackson/src/test/resources/v03/json_data_with_ext_upper_case.json
+++ b/formats/json-jackson/src/test/resources/v03/json_data_with_ext_upper_case.json
@@ -1,0 +1,14 @@
+{
+    "specversion": "0.3",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "schemaurl": "http://localhost/schema",
+    "datacontenttype": "application/json",
+    "data": {},
+    "subject": "sub",
+    "time": "2018-04-26T14:48:09+02:00",
+    "aString": "aaa",
+    "aBoolean": true,
+    "aNumber": 10
+}

--- a/formats/json-jackson/src/test/resources/v1/json_data_with_ext_invalid.json
+++ b/formats/json-jackson/src/test/resources/v1/json_data_with_ext_invalid.json
@@ -1,0 +1,15 @@
+{
+    "specversion": "1.0",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "dataschema": "http://localhost/schema",
+    "datacontenttype": "application/json",
+    "data": {},
+    "subject": "sub",
+    "time": "2018-04-26T14:48:09+02:00",
+    "astring": "aaa",
+    "aboolean": true,
+    "anumber": 10,
+    "a_invalid_name": "invalidName"
+}

--- a/formats/json-jackson/src/test/resources/v1/json_data_with_ext_upper_case.json
+++ b/formats/json-jackson/src/test/resources/v1/json_data_with_ext_upper_case.json
@@ -1,0 +1,14 @@
+{
+    "specversion": "1.0",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "dataschema": "http://localhost/schema",
+    "datacontenttype": "application/json",
+    "data": {},
+    "subject": "sub",
+    "time": "2018-04-26T14:48:09+02:00",
+    "aString": "aaa",
+    "aBoolean": true,
+    "aNumber": 10
+}


### PR DESCRIPTION
CloudEventDeserializer by cloudevents-json-jackson throws an exception when an invalid extension key is included.
Since the extension attribute is not a madatory value, why don't CloudEventDeserializer ignore invalid attributes and run Deserialize?

I modified to ignore the invalid extensionName in CloudEventDeserializer. 

Fixes #428 