### PR TITLE
Handle NullNode for optional attributes in Jackson CloudEventDeserializer

### DIFF
--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -176,12 +176,12 @@ class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
         }
 
         private String getOptionalStringNode(ObjectNode objNode, JsonParser p, String attributeName) throws JsonProcessingException {
-            JsonNode unparsedSpecVersion = objNode.remove(attributeName);
-            if (unparsedSpecVersion == null || unparsedSpecVersion instanceof NullNode) {
+            JsonNode unparsedAttribute = objNode.remove(attributeName);
+            if (unparsedAttribute == null || unparsedAttribute instanceof NullNode) {
                 return null;
             }
-            assertNodeType(unparsedSpecVersion, JsonNodeType.STRING, attributeName, null);
-            return unparsedSpecVersion.asText();
+            assertNodeType(unparsedAttribute, JsonNodeType.STRING, attributeName, null);
+            return unparsedAttribute.asText();
         }
 
         private void assertNodeType(JsonNode node, JsonNodeType type, String attributeName, String desc) throws JsonProcessingException {

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/CloudEventDeserializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
@@ -176,7 +177,7 @@ class CloudEventDeserializer extends StdDeserializer<CloudEvent> {
 
         private String getOptionalStringNode(ObjectNode objNode, JsonParser p, String attributeName) throws JsonProcessingException {
             JsonNode unparsedSpecVersion = objNode.remove(attributeName);
-            if (unparsedSpecVersion == null) {
+            if (unparsedSpecVersion == null || unparsedSpecVersion instanceof NullNode) {
                 return null;
             }
             assertNodeType(unparsedSpecVersion, JsonNodeType.STRING, attributeName, null);

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
@@ -27,14 +27,12 @@ import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.format.EventDeserializationException;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.rw.CloudEventRWException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -47,7 +45,7 @@ import static org.assertj.core.api.Assertions.*;
 
 class JsonFormatTest {
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @ParameterizedTest
     @MethodSource("serializeTestArgumentsDefault")
@@ -184,6 +182,7 @@ class JsonFormatTest {
     public static Stream<Arguments> deserializeTestArguments() {
         return Stream.of(
             Arguments.of("v03/min.json", V03_MIN),
+            Arguments.of("v03/min_subject_null.json", V03_MIN),
             Arguments.of("v03/json_data.json", normalizeToJsonValueIfNeeded(V03_WITH_JSON_DATA)),
             Arguments.of("v03/json_data_with_ext.json", normalizeToJsonValueIfNeeded(V03_WITH_JSON_DATA_WITH_EXT)),
             Arguments.of("v03/base64_json_data.json", V03_WITH_JSON_DATA),
@@ -193,6 +192,7 @@ class JsonFormatTest {
             Arguments.of("v03/text_data.json", V03_WITH_TEXT_DATA),
             Arguments.of("v03/base64_text_data.json", V03_WITH_TEXT_DATA),
             Arguments.of("v1/min.json", V1_MIN),
+            Arguments.of("v1/min_subject_null.json", V1_MIN),
             Arguments.of("v1/json_data.json", normalizeToJsonValueIfNeeded(V1_WITH_JSON_DATA)),
             Arguments.of("v1/json_data_with_ext.json", normalizeToJsonValueIfNeeded(V1_WITH_JSON_DATA_WITH_EXT)),
             Arguments.of("v1/base64_json_data.json", V1_WITH_JSON_DATA),

--- a/formats/json-jackson/src/test/resources/v03/min_subject_null.json
+++ b/formats/json-jackson/src/test/resources/v03/min_subject_null.json
@@ -1,0 +1,7 @@
+{
+    "specversion": "0.3",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "subject": null
+}

--- a/formats/json-jackson/src/test/resources/v1/min_subject_null.json
+++ b/formats/json-jackson/src/test/resources/v1/min_subject_null.json
@@ -1,0 +1,7 @@
+{
+    "specversion": "1.0",
+    "id": "1",
+    "type": "mock.test",
+    "source": "http://localhost/source",
+    "subject": null
+}


### PR DESCRIPTION
In `getOptionalStringNode` we should handle `JsonNode`s that are
instances of `NullNode`.

Fixes #430 