### PR TITLE
Optimize `isCloudEventsHeader` check

### DIFF
--- a/core/src/main/java/io/cloudevents/core/impl/StringUtils.java
+++ b/core/src/main/java/io/cloudevents/core/impl/StringUtils.java
@@ -21,6 +21,10 @@ import javax.annotation.Nonnull;
 
 final public class StringUtils {
 
+    private StringUtils() {
+        // Prevent construction.
+    }
+
     public static boolean startsWithIgnoreCase(@Nonnull final String s, @Nonnull final String prefix) {
         return s.regionMatches(true /* ignoreCase */, 0, prefix, 0, prefix.length());
     }

--- a/core/src/main/java/io/cloudevents/core/impl/StringUtils.java
+++ b/core/src/main/java/io/cloudevents/core/impl/StringUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.core.impl;
+
+import javax.annotation.Nonnull;
+
+final public class StringUtils {
+
+    public static boolean startsWithIgnoreCase(@Nonnull final String s, @Nonnull final String prefix) {
+        return s.regionMatches(true /* ignoreCase */, 0, prefix, 0, prefix.length());
+    }
+}

--- a/core/src/test/java/io/cloudevents/core/impl/StringUtilsTest.java
+++ b/core/src/test/java/io/cloudevents/core/impl/StringUtilsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.core.impl;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+public class StringUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("startsWithIgnoreCaseArgs")
+    public void startsWithIgnoreCase(final String s, final String prefix, final boolean expected) {
+        Assertions.assertThat(StringUtils.startsWithIgnoreCase(s, prefix)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> startsWithIgnoreCaseArgs() {
+        return Stream.of(
+            Arguments.of("s", "s", true),
+            Arguments.of("sa", "S", true),
+            Arguments.of("saS", "As", false),
+            Arguments.of("sasso", "SASO", false),
+            Arguments.of("sasso", "SaSsO", true)
+        );
+    }
+}

--- a/http/basic/src/main/java/io/cloudevents/http/impl/HttpMessageReader.java
+++ b/http/basic/src/main/java/io/cloudevents/http/impl/HttpMessageReader.java
@@ -19,6 +19,7 @@ package io.cloudevents.http.impl;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.data.BytesCloudEventData;
+import io.cloudevents.core.impl.StringUtils;
 import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
 
 import java.util.function.BiConsumer;
@@ -47,7 +48,7 @@ public class HttpMessageReader extends BaseGenericBinaryMessageReaderImpl<String
 
     @Override
     protected boolean isCloudEventsHeader(String key) {
-        return key != null && key.length() > 3 && key.substring(0, CE_PREFIX.length()).toLowerCase().startsWith(CE_PREFIX);
+        return key != null && key.length() > CE_PREFIX.length() && StringUtils.startsWithIgnoreCase(key, CE_PREFIX);
     }
 
     @Override

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
@@ -19,6 +19,7 @@ package io.cloudevents.http.restful.ws.impl;
 
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.data.BytesCloudEventData;
+import io.cloudevents.core.impl.StringUtils;
 import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -46,7 +47,7 @@ public final class BinaryRestfulWSMessageReaderImpl extends BaseGenericBinaryMes
 
     @Override
     protected boolean isCloudEventsHeader(String key) {
-        return key.length() > 3 && key.substring(0, CE_PREFIX.length()).toLowerCase().startsWith(CE_PREFIX);
+        return key.length() > CE_PREFIX.length() && StringUtils.startsWithIgnoreCase(key, CE_PREFIX);
     }
 
     @Override

--- a/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/BinaryVertxMessageReaderImpl.java
+++ b/http/vertx/src/main/java/io/cloudevents/http/vertx/impl/BinaryVertxMessageReaderImpl.java
@@ -19,6 +19,7 @@ package io.cloudevents.http.vertx.impl;
 
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.data.BytesCloudEventData;
+import io.cloudevents.core.impl.StringUtils;
 import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
@@ -45,7 +46,7 @@ public class BinaryVertxMessageReaderImpl extends BaseGenericBinaryMessageReader
 
     @Override
     protected boolean isCloudEventsHeader(String key) {
-        return key.length() > 3 && key.substring(0, CloudEventsHeaders.CE_PREFIX.length()).toLowerCase().startsWith(CloudEventsHeaders.CE_PREFIX);
+        return key.length() > CloudEventsHeaders.CE_PREFIX.length() && StringUtils.startsWithIgnoreCase(key, CloudEventsHeaders.CE_PREFIX);
     }
 
     @Override

--- a/kafka/src/main/java/io/cloudevents/kafka/impl/KafkaBinaryMessageReaderImpl.java
+++ b/kafka/src/main/java/io/cloudevents/kafka/impl/KafkaBinaryMessageReaderImpl.java
@@ -44,7 +44,7 @@ public class KafkaBinaryMessageReaderImpl extends BaseGenericBinaryMessageReader
 
     @Override
     protected boolean isCloudEventsHeader(String key) {
-        return key.length() > 3 && key.substring(0, KafkaHeaders.CE_PREFIX.length()).startsWith(KafkaHeaders.CE_PREFIX);
+        return key.length() > KafkaHeaders.CE_PREFIX.length() && key.startsWith(KafkaHeaders.CE_PREFIX);
     }
 
     @Override

--- a/spring/src/main/java/io/cloudevents/spring/messaging/MessageBinaryMessageReader.java
+++ b/spring/src/main/java/io/cloudevents/spring/messaging/MessageBinaryMessageReader.java
@@ -20,6 +20,7 @@ import java.util.function.BiConsumer;
 
 import io.cloudevents.SpecVersion;
 import io.cloudevents.core.data.BytesCloudEventData;
+import io.cloudevents.core.impl.StringUtils;
 import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
 
 import static io.cloudevents.spring.messaging.CloudEventsHeaders.CE_PREFIX;
@@ -51,8 +52,7 @@ class MessageBinaryMessageReader extends BaseGenericBinaryMessageReaderImpl<Stri
 
 	@Override
 	protected boolean isCloudEventsHeader(String key) {
-		return key != null && key.length() > 3
-				&& key.substring(0, CE_PREFIX.length()).toLowerCase().startsWith(CE_PREFIX);
+		return key != null && key.length() > CE_PREFIX.length() && StringUtils.startsWithIgnoreCase(key, CE_PREFIX);
 	}
 
 	@Override


### PR DESCRIPTION
Instead of using:
```java
key.substring(0, CE_PREFIX.length()).toLowerCase().startsWith(CE_PREFIX);
```
that allocates 2 new strings, we can just use:
```java
key.regionMatches(true /* ignoreCase */, 0, CE_PREFIX, 0, CE_PREFIX.length());
```

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>