### PR TITLE
Add `CONTRIBUTING.md` and `MAINTAINERS.md` files for CLO monitor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,19 @@
-# Pull Request Guidelines
+# Contributing to CloudEvents' Java SDK
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+We welcome contributions from the community! Please take some time to become
+acquainted with the process before submitting a pull request. There are just
+a few things to keep in mind.
+
+# Pull Requests
+
+Typically, a pull request should relate to an existing issue. If you have
+found a bug, want to add an improvement, or suggest an API change, please
+create an issue before proceeding with a pull request. For very minor changes
+such as typos in the documentation this isn't really necessary.
+
+## Pull Request Guidelines
 
 Here you will find step by step guidance for creating, submitting and updating
 a pull request in this repository. We hope it will help you have an easy time

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,9 @@
+# Maintainers
+
+Currently, active maintainers who may be found in the CNCF Slack.
+
+- [Pierangelo Di Pilato](https://github.com/pierDipi)
+
 # Maintainer's Guide
 
 ## Release Process


### PR DESCRIPTION
These 2 new files are based on the existing `pr_guidelines.md`
and `maintainers_guide.md` + some copied content from
https://github.com/cloudevents/sdk-javascript.

I don't know how to test this, so I'll re-check the reports linked
in https://github.com/cloudevents/sdk-java/issues/453 after merge.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>