### PR TITLE
support dynamic data content type

### DIFF
--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -47,7 +47,7 @@ public final class JsonFormat implements EventFormat {
     /**
      * Suppoted Content type
      */
-    private static final Pattern PATTERN_CONTENT_TYPE = Pattern.compile("^(application|text)\\/([a-zA-Z]+\\+)?json$");
+    private static final Pattern JSON_CONTENT_TYPE = Pattern.compile("^(application|text)\\/([a-zA-Z]+\\+)?json$");
     private final ObjectMapper mapper;
     private final JsonFormatOptions options;
 
@@ -218,6 +218,6 @@ public final class JsonFormat implements EventFormat {
 
     static boolean dataIsJsonContentType(String contentType) {
         // If content type, spec states that we should assume is json
-        return contentType == null || PATTERN_CONTENT_TYPE.matcher(contentType).matches();
+        return contentType == null || JSON_CONTENT_TYPE.matcher(contentType).matches();
     }
 }

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -47,7 +47,7 @@ public final class JsonFormat implements EventFormat {
     /**
      * Suppoted Content type
      */
-    private static final Pattern JSON_CONTENT_TYPE = Pattern.compile("^(application|text)\\/([a-zA-Z]+\\+)?json$");
+    private static final Pattern JSON_CONTENT_TYPE_PATTERN = Pattern.compile("^(application|text)\\/([a-zA-Z]+\\+)?json$");
     private final ObjectMapper mapper;
     private final JsonFormatOptions options;
 
@@ -218,6 +218,6 @@ public final class JsonFormat implements EventFormat {
 
     static boolean dataIsJsonContentType(String contentType) {
         // If content type, spec states that we should assume is json
-        return contentType == null || JSON_CONTENT_TYPE.matcher(contentType).matches();
+        return contentType == null || JSON_CONTENT_TYPE_PATTERN.matcher(contentType).matches();
     }
 }

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -45,7 +45,7 @@ public final class JsonFormat implements EventFormat {
      */
     public static final String CONTENT_TYPE = "application/cloudevents+json";
     /**
-     * Suppoted Content type
+     * JSON Data Content Type Discriminator
      */
     private static final Pattern JSON_CONTENT_TYPE_PATTERN = Pattern.compile("^(application|text)\\/([a-zA-Z]+\\+)?json$");
     private final ObjectMapper mapper;

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -29,6 +29,7 @@ import io.cloudevents.rw.CloudEventDataMapper;
 import io.cloudevents.rw.CloudEventRWException;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 /**
  * Implementation of {@link EventFormat} for <a href="https://github.com/cloudevents/spec/blob/v1.0/json-format.md">JSON event format</a>
@@ -43,7 +44,10 @@ public final class JsonFormat implements EventFormat {
      * Content type associated with the JSON event format
      */
     public static final String CONTENT_TYPE = "application/cloudevents+json";
-
+    /**
+     * Suppoted Content type
+     */
+    private static final Pattern PATTERN_CONTENT_TYPE = Pattern.compile("^(application|text)\\/([a-zA-Z]+\\+)?json$");
     private final ObjectMapper mapper;
     private final JsonFormatOptions options;
 
@@ -214,6 +218,6 @@ public final class JsonFormat implements EventFormat {
 
     static boolean dataIsJsonContentType(String contentType) {
         // If content type, spec states that we should assume is json
-        return contentType == null || contentType.startsWith("application/json") || contentType.startsWith("text/json");
+        return contentType == null || PATTERN_CONTENT_TYPE.matcher(contentType).matches();
     }
 }

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonCloudEventDataTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonCloudEventDataTest.java
@@ -20,12 +20,9 @@ package io.cloudevents.jackson;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
-import io.cloudevents.core.impl.StringUtils;
 import io.cloudevents.core.mock.MyCloudEventData;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.core.test.Data;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -65,7 +62,7 @@ public class JsonCloudEventDataTest {
         return Stream.of(
             Arguments.of("application/json"),
             Arguments.of("text/json"),
-            Arguments.of("application/fubar+json")
+            Arguments.of("application/foobar+json")
         );
     }
 }

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonCloudEventDataTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonCloudEventDataTest.java
@@ -52,6 +52,8 @@ public class JsonCloudEventDataTest {
                 return new MyCloudEventData(((JsonCloudEventData) data).getNode().asInt());
             });
 
+        assertThat(deserialized.getDataContentType())
+            .isEqualTo(contentType);
         assertThat(deserialized.getData())
             .isInstanceOf(MyCloudEventData.class);
         assertThat(((MyCloudEventData) deserialized.getData()).getValue())

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonCloudEventDataTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonCloudEventDataTest.java
@@ -20,19 +20,27 @@ package io.cloudevents.jackson;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.impl.StringUtils;
 import io.cloudevents.core.mock.MyCloudEventData;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.core.test.Data;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonCloudEventDataTest {
 
-    @Test
-    public void testMapper() {
+    @ParameterizedTest
+    @MethodSource("textContentArguments")
+    public void testMapper(String contentType) {
         CloudEvent event = CloudEventBuilder.v1(Data.V1_MIN)
-            .withData("application/json", new JsonCloudEventData(JsonNodeFactory.instance.numberNode(10)))
+            .withData(contentType, new JsonCloudEventData(JsonNodeFactory.instance.numberNode(10)))
             .build();
 
         byte[] serialized = EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE)
@@ -53,4 +61,11 @@ public class JsonCloudEventDataTest {
             .isEqualTo(10);
     }
 
+    public static Stream<Arguments> textContentArguments() {
+        return Stream.of(
+            Arguments.of("application/json"),
+            Arguments.of("text/json"),
+            Arguments.of("application/fubar+json")
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/cloudevents/sdk-java/issues/470
Now checks if dataContentType matches the next regex.

`^(application|text)\/([a-zA-Z]+\+)?json$")`

This regex support 
`application/foobar+json`
or standard
```
application/json
text/json
```