### PR TITLE
fix: strip parameters from data content types to assess if it's JSON format

### DIFF
--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -47,7 +47,7 @@ public final class JsonFormat implements EventFormat {
     /**
      * JSON Data Content Type Discriminator
      */
-    private static final Pattern JSON_CONTENT_TYPE_PATTERN = Pattern.compile("^(application|text)\\/([a-zA-Z]+\\+)?json$");
+    private static final Pattern JSON_CONTENT_TYPE_PATTERN = Pattern.compile("^(application|text)\\/([a-zA-Z]+\\+)?json(;.*)*$");
     private final ObjectMapper mapper;
     private final JsonFormatOptions options;
 


### PR DESCRIPTION
Fixes https://github.com/cloudevents/sdk-java/issues/481

Signed-off-by: Frederic Delechamp <fdelechamp@guidewire.com>