### PR TITLE
Refactor to Facilitate Decoupling from Concrete Implementations of EventFormat

### DIFF
--- a/core/src/main/java/io/cloudevents/core/format/ContentType.java
+++ b/core/src/main/java/io/cloudevents/core/format/ContentType.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.core.format;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.rw.CloudEventDataMapper;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * <p>A construct that aggregates a two-part identifier of file formats and format contents transmitted on the Internet.
+ *
+ * <p>The two parts of a {@code ContentType} are its <em>type</em> and a <em>subtype</em>; separated by a forward slash ({@code /}).
+ *
+ * @see io.cloudevents.core.format.EventFormat
+ */
+@ParametersAreNonnullByDefault
+public enum ContentType {
+
+    /**
+     * Content type associated with the CSV event format
+     */
+    CSV("application/cloudevents+csv"),
+    /**
+     * Content type associated with the JSON event format
+     */
+    JSON("application/cloudevents+json"),
+    /**
+     * The content type for transports sending cloudevents in the protocol buffer format.
+     */
+    PROTO("application/cloudevents+protobuf"),
+    /**
+     * The content type to set for the "datacontenttype" attribute if the data is stored in protocol buffer format.>
+     * Note that if this content type is used, the stored data must be wrapped in {@link com.google.protobuf.Any} as specified by the protobuf format spec.>
+     */
+    PROTO_DATA("application/protobuf"),
+    /**
+     * The content type for transports sending cloudevents in XML format.
+     */
+    XML("application/cloudevents+xml");
+
+    private String value;
+
+    private ContentType(String value) { this.value = value; }
+
+    /**
+     * Return a string consisting of the slash-delimited ({@code /}) two-part identifier for this {@code enum} constant.
+     */
+    public String value() { return value; }
+
+    /**
+     * Return a string consisting of the slash-delimited ({@code /}) two-part identifier for this {@code enum} constant.
+     */
+    @Override
+    public String toString() { return value(); }
+
+}

--- a/core/src/main/java/io/cloudevents/core/format/ContentType.java
+++ b/core/src/main/java/io/cloudevents/core/format/ContentType.java
@@ -38,10 +38,6 @@ import java.util.Set;
 public enum ContentType {
 
     /**
-     * Content type associated with the CSV event format
-     */
-    CSV("application/cloudevents+csv"),
-    /**
      * Content type associated with the JSON event format
      */
     JSON("application/cloudevents+json"),

--- a/core/src/main/java/io/cloudevents/core/format/ContentType.java
+++ b/core/src/main/java/io/cloudevents/core/format/ContentType.java
@@ -30,6 +30,8 @@ import java.util.Set;
  *
  * <p>The two parts of a {@code ContentType} are its <em>type</em> and a <em>subtype</em>; separated by a forward slash ({@code /}).
  *
+ * <p>The constants enumerated by {@code ContentType} correspond <em>only</em> to the specialized formats supported by the Java™ SDK for CloudEvents.
+ *
  * @see io.cloudevents.core.format.EventFormat
  */
 @ParametersAreNonnullByDefault
@@ -47,11 +49,6 @@ public enum ContentType {
      * The content type for transports sending cloudevents in the protocol buffer format.
      */
     PROTO("application/cloudevents+protobuf"),
-    /**
-     * The content type to set for the "datacontenttype" attribute if the data is stored in protocol buffer format.>
-     * Note that if this content type is used, the stored data must be wrapped in {@link com.google.protobuf.Any} as specified by the protobuf format spec.>
-     */
-    PROTO_DATA("application/protobuf"),
     /**
      * The content type for transports sending cloudevents in XML format.
      */

--- a/core/src/main/java/io/cloudevents/core/provider/EventFormatProvider.java
+++ b/core/src/main/java/io/cloudevents/core/provider/EventFormatProvider.java
@@ -109,6 +109,4 @@ public final class EventFormatProvider {
 	public EventFormat resolveFormat(ContentType contentType) {
 		return this.formats.get(contentType.value());
 	}
-
-
 }

--- a/core/src/main/java/io/cloudevents/core/provider/EventFormatProvider.java
+++ b/core/src/main/java/io/cloudevents/core/provider/EventFormatProvider.java
@@ -25,6 +25,7 @@ import java.util.stream.StreamSupport;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.lang.Nullable;
 
@@ -97,5 +98,17 @@ public final class EventFormatProvider {
 		}
 		return this.formats.get(contentType);
 	}
+
+	/**
+	 * Resolve an event format starting from the content type.
+	 *
+	 * @param contentType the content type to resolve the event format
+	 * @return null if no format was found for the provided content type
+	 */
+	@Nullable
+	public EventFormat resolveFormat(ContentType contentType) {
+		return this.formats.get(contentType.value());
+	}
+
 
 }

--- a/core/src/test/java/io/cloudevents/core/provider/EventFormatProviderTest.java
+++ b/core/src/test/java/io/cloudevents/core/provider/EventFormatProviderTest.java
@@ -20,7 +20,6 @@ package io.cloudevents.core.provider;
 import io.cloudevents.core.mock.CSVFormat;
 import org.junit.jupiter.api.Test;
 
-import static io.cloudevents.core.format.ContentType.CSV;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EventFormatProviderTest {
@@ -42,9 +41,4 @@ public class EventFormatProviderTest {
         assertThat(EventFormatProvider.getInstance().getContentTypes()).hasSize(1);
     }
 
-    @Test
-    void resolveCSVUsingEnum() {
-        assertThat(EventFormatProvider.getInstance().resolveFormat(CSV))
-            .isInstanceOf(CSVFormat.class);
-    }
 }

--- a/core/src/test/java/io/cloudevents/core/provider/EventFormatProviderTest.java
+++ b/core/src/test/java/io/cloudevents/core/provider/EventFormatProviderTest.java
@@ -20,6 +20,7 @@ package io.cloudevents.core.provider;
 import io.cloudevents.core.mock.CSVFormat;
 import org.junit.jupiter.api.Test;
 
+import static io.cloudevents.core.format.ContentType.CSV;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EventFormatProviderTest {
@@ -41,4 +42,9 @@ public class EventFormatProviderTest {
         assertThat(EventFormatProvider.getInstance().getContentTypes()).hasSize(1);
     }
 
+    @Test
+    void resolveCSVUsingEnum() {
+        assertThat(EventFormatProvider.getInstance().resolveFormat(CSV))
+            .isInstanceOf(CSVFormat.class);
+    }
 }

--- a/docs/json-jackson.md
+++ b/docs/json-jackson.md
@@ -28,9 +28,9 @@ adding the dependency to your project:
 
 ```java
 import io.cloudevents.CloudEvent;
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.format.EventFormatProvider;
 import io.cloudevents.core.builder.CloudEventBuilder;
-import io.cloudevents.jackson.JsonFormat;
 
 CloudEvent event = CloudEventBuilder.v1()
     .withId("hello")
@@ -40,7 +40,7 @@ CloudEvent event = CloudEventBuilder.v1()
 
 byte[]serialized = EventFormatProvider
     .getInstance()
-    .resolveFormat(JsonFormat.CONTENT_TYPE)
+    .resolveFormat(ContentType.JSON)
     .serialize(event);
 ```
 

--- a/docs/protobuf.md
+++ b/docs/protobuf.md
@@ -30,9 +30,9 @@ No further configuration is required is use the module.
 
 ```java
 import io.cloudevents.CloudEvent;
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.format.EventFormatProvider;
 import io.cloudevents.core.builder.CloudEventBuilder;
-import io.cloudevents.protobuf.ProtobufFormat;
 
 CloudEvent event = CloudEventBuilder.v1()
     .withId("hello")
@@ -42,7 +42,7 @@ CloudEvent event = CloudEventBuilder.v1()
 
 byte[]serialized = EventFormatProvider
     .getInstance()
-    .resolveFormat(ProtobufFormat.CONTENT_TYPE)
+    .resolveFormat(ContentType.PROTO)
     .serialize(event);
 ```
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -29,9 +29,9 @@ adding the dependency to your project:
 
 ```java
 import io.cloudevents.CloudEvent;
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.format.EventFormatProvider;
 import io.cloudevents.core.builder.CloudEventBuilder;
-import io.cloudevents.xml.XMLFormat;
 
 CloudEvent event = CloudEventBuilder.v1()
     .withId("hello")
@@ -41,7 +41,7 @@ CloudEvent event = CloudEventBuilder.v1()
 
 byte[] serialized = EventFormatProvider
     .getInstance()
-    .resolveFormat(XMLFormat.CONTENT_TYPE)
+    .resolveFormat(ContentType.XML)
     .serialize(event);
 ```
 

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -44,7 +44,7 @@ public final class JsonFormat implements EventFormat {
     /**
      * Content type associated with the JSON event format
      */
-    public static final String CONTENT_TYPE = "application/cloudevents+json";
+    public static final String CONTENT_TYPE = ContentType.JSON.value();
     /**
      * JSON Data Content Type Discriminator
      */

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -44,7 +44,7 @@ public final class JsonFormat implements EventFormat {
     /**
      * Content type associated with the JSON event format
      */
-    public static final String CONTENT_TYPE = ContentType.JSON.value();
+    public static final String CONTENT_TYPE = "application/cloudevents+json";
     /**
      * JSON Data Content Type Discriminator
      */

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.format.EventDeserializationException;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.format.EventSerializationException;
@@ -219,5 +220,10 @@ public final class JsonFormat implements EventFormat {
     static boolean dataIsJsonContentType(String contentType) {
         // If content type, spec states that we should assume is json
         return contentType == null || JSON_CONTENT_TYPE_PATTERN.matcher(contentType).matches();
+    }
+
+    static boolean dataIsJsonContentType(ContentType contentType) {
+        // If content type, spec states that we should assume is json
+        return dataIsJsonContentType(contentType.value());
     }
 }

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -221,9 +221,4 @@ public final class JsonFormat implements EventFormat {
         // If content type, spec states that we should assume is json
         return contentType == null || JSON_CONTENT_TYPE_PATTERN.matcher(contentType).matches();
     }
-
-    static boolean dataIsJsonContentType(ContentType contentType) {
-        // If content type, spec states that we should assume is json
-        return dataIsJsonContentType(contentType.value());
-    }
 }

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
@@ -231,7 +231,6 @@ class JsonFormatTest {
         return Stream.of(
             Arguments.of(CSV),
             Arguments.of(PROTO),
-            Arguments.of(PROTO_DATA),
             Arguments.of(XML)
         );
     }

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/JsonFormatTest.java
@@ -58,24 +58,8 @@ class JsonFormatTest {
     }
 
     @ParameterizedTest
-    @MethodSource("jsonContentTypesEnum")
-    void isJsonContentType(ContentType contentType) {
-        boolean json = JsonFormat.dataIsJsonContentType(contentType);
-
-        assertThat(json).isTrue();
-    }
-
-    @ParameterizedTest
     @MethodSource("wrongJsonContentTypes")
     void isNotJsonContentType(String contentType) {
-        boolean json = JsonFormat.dataIsJsonContentType(contentType);
-
-        assertThat(json).isFalse();
-    }
-
-    @ParameterizedTest
-    @MethodSource("wrongJsonContentTypesEnums")
-    void isNotJsonContentType(ContentType contentType) {
         boolean json = JsonFormat.dataIsJsonContentType(contentType);
 
         assertThat(json).isFalse();
@@ -210,12 +194,6 @@ class JsonFormatTest {
         );
     }
 
-    static Stream<Arguments> jsonContentTypesEnum() {
-        return Stream.of(
-            Arguments.of(JSON)
-        );
-    }
-
     static Stream<Arguments> wrongJsonContentTypes() {
         return Stream.of(
             Arguments.of("applications/json"),
@@ -226,15 +204,6 @@ class JsonFormatTest {
             Arguments.of("test/json")
         );
     }
-
-    static Stream<Arguments> wrongJsonContentTypesEnums() {
-        return Stream.of(
-            Arguments.of(CSV),
-            Arguments.of(PROTO),
-            Arguments.of(XML)
-        );
-    }
-
 
     public static Stream<Arguments> serializeTestArgumentsDefault() {
         return Stream.of(

--- a/formats/protobuf/src/main/java/io/cloudevents/protobuf/ProtobufFormat.java
+++ b/formats/protobuf/src/main/java/io/cloudevents/protobuf/ProtobufFormat.java
@@ -39,7 +39,7 @@ public class ProtobufFormat implements EventFormat {
     /**
      * The content type for transports sending cloudevents in the protocol buffer format.
      */
-    public static final String PROTO_CONTENT_TYPE = ContentType.PROTO.value();
+    public static final String PROTO_CONTENT_TYPE = "application/cloudevents+protobuf";
     /**
      * The content type to set for the "datacontenttype" attribute if the data is stored in protocol buffer format.
      * Note that if this content type is used, the stored data must be wrapped in {@link com.google.protobuf.Any} as specified by the protobuf format spec.

--- a/formats/protobuf/src/main/java/io/cloudevents/protobuf/ProtobufFormat.java
+++ b/formats/protobuf/src/main/java/io/cloudevents/protobuf/ProtobufFormat.java
@@ -20,6 +20,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.format.EventDeserializationException;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.format.EventSerializationException;
@@ -38,7 +39,7 @@ public class ProtobufFormat implements EventFormat {
     /**
      * The content type for transports sending cloudevents in the protocol buffer format.
      */
-    public static final String PROTO_CONTENT_TYPE = "application/cloudevents+protobuf";
+    public static final String PROTO_CONTENT_TYPE = ContentType.PROTO.value();
     /**
      * The content type to set for the "datacontenttype" attribute if the data is stored in protocol buffer format.
      * Note that if this content type is used, the stored data must be wrapped in {@link com.google.protobuf.Any} as specified by the protobuf format spec.

--- a/formats/xml/src/main/java/io/cloudevents/xml/XMLFormat.java
+++ b/formats/xml/src/main/java/io/cloudevents/xml/XMLFormat.java
@@ -39,7 +39,7 @@ public class XMLFormat implements EventFormat {
     /**
      * The content type for transports sending cloudevents in XML format.
      */
-    public static final String XML_CONTENT_TYPE = ContentType.XML.value();
+    public static final String XML_CONTENT_TYPE = "application/cloudevents+xml";
 
     @Override
     public byte[] serialize(CloudEvent event) throws EventSerializationException {

--- a/formats/xml/src/main/java/io/cloudevents/xml/XMLFormat.java
+++ b/formats/xml/src/main/java/io/cloudevents/xml/XMLFormat.java
@@ -19,6 +19,7 @@ package io.cloudevents.xml;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.format.EventDeserializationException;
 import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.format.EventSerializationException;
@@ -38,7 +39,7 @@ public class XMLFormat implements EventFormat {
     /**
      * The content type for transports sending cloudevents in XML format.
      */
-    public static final String XML_CONTENT_TYPE = "application/cloudevents+xml";
+    public static final String XML_CONTENT_TYPE = ContentType.XML.value();
 
     @Override
     public byte[] serialize(CloudEvent event) throws EventSerializationException {


### PR DESCRIPTION
Closes #537

### Example Usage of Proposed Refactor

```java
import io.cloudevents.CloudEvent;
import io.cloudevents.core.format.EventFormatProvider;
import io.cloudevents.core.builder.CloudEventBuilder;
import io.cloudevents.core.format.ContentType; // New constant to facilitate loose coupling in client applications

CloudEvent event = ...;

byte[] serialized = EventFormatProvider
    .getInstance()
    .resolveFormat(ContentType.PROTO) // EventFormatProvider.resolveFormat(...) overloaded 
    .serialize(event);                // for string and enum input options
```
