### PR TITLE
feat: Add Avro EventFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Javadocs are available on [javadoc.io](https://www.javadoc.io):
 
 -   [cloudevents-api](https://www.javadoc.io/doc/io.cloudevents/cloudevents-api)
 -   [cloudevents-core](https://www.javadoc.io/doc/io.cloudevents/cloudevents-core)
+-   [cloudevents-avro](https://www.javadoc.io/doc/io.cloudevents/cloudevents-avro)
 -   [cloudevents-json-jackson](https://www.javadoc.io/doc/io.cloudevents/cloudevents-json-jackson)
 -   [cloudevents-protobuf](https://www.javadoc.io/doc/io.cloudevents/cloudevents-protobuf)
 -   [cloudevents-xml](https://www.javadoc.io/doc/io.cloudevents/cloudevents-xml)

--- a/docs/avro.md
+++ b/docs/avro.md
@@ -1,0 +1,96 @@
+---
+title: CloudEvents Avro
+nav_order: 4
+---
+
+# CloudEvents Avro
+
+[![Javadocs](http://www.javadoc.io/badge/io.cloudevents/cloudevents-avro.svg?color=green)](http://www.javadoc.io/doc/io.cloudevents/cloudevents-avro)
+
+This module provides the Avro Buffer (avro) `EventFormat` implementation using the Java
+avro runtime and classes generated from the CloudEvents
+[avro spec](https://github.com/cloudevents/spec/blob/v1.0.1/spec.avro).
+
+# Setup
+For Maven based projects, use the following dependency:
+
+```xml
+<dependency>
+    <groupId>io.cloudevents</groupId>
+    <artifactId>cloudevents-avro</artifactId>
+    <version>x.y.z</version>
+</dependency>
+```
+
+No further configuration is required is use the module.
+
+## Using the avro Event Format
+
+### Event serialization
+
+```java
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.format.EventFormatProvider;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.avro.avroFormat;
+
+CloudEvent event = CloudEventBuilder.v1()
+    .withId("hello")
+    .withType("example.vertx")
+    .withSource(URI.create("http://localhost"))
+    .build();
+
+byte[]serialized = EventFormatProvider
+    .getInstance()
+    .resolveFormat(avroFormat.CONTENT_TYPE)
+    .serialize(event);
+```
+
+The `EventFormatProvider` will automatically resolve the `avroFormat` using the
+`ServiceLoader` APIs.
+
+## Passing avro messages as CloudEvent data.
+
+The `AvroCloudEventData` capability provides a convenience mechanism to handle avro message object data.
+
+### Building
+
+```java
+// Build my business event message.
+com.google.avro.Message myMessage = ..... ;
+
+// Wrap the avro message as CloudEventData.
+CloudEventData ceData = AvroCloudEventData.wrap(myMessage);
+
+// Build the CloudEvent
+CloudEvent event = CloudEventBuilder.v1()
+    .withId("hello")
+    .withType("example.avrodata")
+    .withSource(URI.create("http://localhost"))
+    .withData(ceData)
+    .build();
+```
+
+### Reading
+
+If the `AvroFormat` is used to deserialize a CloudEvent that contains a avro message object as data you can use
+the `AvroCloudEventData` to access it as an 'Any' directly.
+
+```java
+
+// Deserialize the event.
+CloudEvent myEvent = eventFormat.deserialize(raw);
+
+// Get the Data
+CloudEventData eventData = myEvent.getData();
+
+if (ceData instanceOf AvroCloudEventData) {
+
+    // Obtain the avro 'any'
+    Any anAny = ((AvroCloudEventData) eventData).getAny();
+
+    ...
+}
+
+```
+

--- a/docs/avro.md
+++ b/docs/avro.md
@@ -9,7 +9,7 @@ nav_order: 4
 
 This module provides the Avro Buffer (avro) `EventFormat` implementation using the Java
 avro runtime and classes generated from the CloudEvents
-[avro spec](https://github.com/cloudevents/spec/blob/v1.0.1/spec.avro).
+[avro spec](https://github.com/cloudevents/spec/blob/main/spec.avro).
 
 # Setup
 For Maven based projects, use the following dependency:
@@ -24,7 +24,7 @@ For Maven based projects, use the following dependency:
 
 No further configuration is required is use the module.
 
-## Using the avro Event Format
+## Using the Avro Event Format
 
 ### Event serialization
 
@@ -42,55 +42,10 @@ CloudEvent event = CloudEventBuilder.v1()
 
 byte[]serialized = EventFormatProvider
     .getInstance()
-    .resolveFormat(avroFormat.CONTENT_TYPE)
+    .resolveFormat(AvroFormat.CONTENT_TYPE)
     .serialize(event);
 ```
 
 The `EventFormatProvider` will automatically resolve the `avroFormat` using the
 `ServiceLoader` APIs.
-
-## Passing avro messages as CloudEvent data.
-
-The `AvroCloudEventData` capability provides a convenience mechanism to handle avro message object data.
-
-### Building
-
-```java
-// Build my business event message.
-com.google.avro.Message myMessage = ..... ;
-
-// Wrap the avro message as CloudEventData.
-CloudEventData ceData = AvroCloudEventData.wrap(myMessage);
-
-// Build the CloudEvent
-CloudEvent event = CloudEventBuilder.v1()
-    .withId("hello")
-    .withType("example.avrodata")
-    .withSource(URI.create("http://localhost"))
-    .withData(ceData)
-    .build();
-```
-
-### Reading
-
-If the `AvroFormat` is used to deserialize a CloudEvent that contains a avro message object as data you can use
-the `AvroCloudEventData` to access it as an 'Any' directly.
-
-```java
-
-// Deserialize the event.
-CloudEvent myEvent = eventFormat.deserialize(raw);
-
-// Get the Data
-CloudEventData eventData = myEvent.getData();
-
-if (ceData instanceOf AvroCloudEventData) {
-
-    // Obtain the avro 'any'
-    Any anAny = ((AvroCloudEventData) eventData).getAny();
-
-    ...
-}
-
-```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,23 +27,25 @@ Using the Java SDK you can:
 ## Supported features
 
 |                                                    | [v0.3](https://github.com/cloudevents/spec/tree/v0.3) | [v1.0](https://github.com/cloudevents/spec/tree/v1.0) |
-| :------------------------------------------------: | :---------------------------------------------------: | :---------------------------------------------------: |
+|:--------------------------------------------------:|:-----------------------------------------------------:|:-----------------------------------------------------:|
 |                  CloudEvents Core                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
 |               AMQP Protocol Binding                |                          :x:                          |                          :x:                          |
 |             - [Proton](amqp-proton.md)             |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|                 AVRO Event Format                  |                          :x:                          |                          :x:                          |
+|                 AVRO Event Format                  |                          :x:                          |                  :heavy_check_mark:                   |
 |               HTTP Protocol Binding                |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
 |             - [Vert.x](http-vertx.md)              |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
 | - [Jakarta Restful WS](http-jakarta-restful-ws.md) |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
 |              - [Basic](http-basic.md)              |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
 |               - [Spring](spring.md)                |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|               - [http4k][http4k]<sup>†</sup>       |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|           - [http4k][http4k]<sup>†</sup>           |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
 |                 JSON Event Format                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                 - [Avro](avro.md)                  |                          :x:                          |                  :heavy_check_mark:                   |
+|                 Avro Event Format                  |                          :x:                          |                  :heavy_check_mark:                   |
 |            - [Jackson](json-jackson.md)            |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|                Protobuf Event Format               |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|            - [Proto](protobuf.md)                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|                XML Event Format                    |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|            - [XML](xml.md)                         |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|               Protobuf Event Format                |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|               - [Proto](protobuf.md)               |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                  XML Event Format                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                  - [XML](xml.md)                   |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
 |         [Kafka Protocol Binding](kafka.md)         |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
 |               MQTT Protocol Binding                |                          :x:                          |                          :x:                          |
 |               NATS Protocol Binding                |                          :x:                          |                          :x:                          |
@@ -94,6 +96,8 @@ a different feature from the different sub specs of
 -   [`cloudevents-bom`] Module providing a
     [bill of materials (BOM)](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms)
     for easier integration of CloudEvents in other projects
+-   [`cloudevents-avro`] Implementation of [Avro Event format] using
+    [Apache Avro](https://avro.apache.org/)
 -   [`cloudevents-json-jackson`] Implementation of [JSON Event format] with
     [Jackson](https://github.com/FasterXML/jackson)
 -   [`cloudevents-protobuf`] Implementation of [Protobuf Event format] using code generated
@@ -116,6 +120,7 @@ a different feature from the different sub specs of
 You can look at the latest published artifacts on
 [Maven Central](https://search.maven.org/search?q=g:io.cloudevents).
 
+[Avro Event format]: https://github.com/cloudevents/spec/blob/main/avro-format.md
 [JSON Event format]: https://github.com/cloudevents/spec/blob/v1.0/json-format.md
 [Protobuf Event format]: https://github.com/cloudevents/spec/blob/v1.0.1/protobuf-format.md
 [HTTP Protocol Binding]: https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md
@@ -124,6 +129,7 @@ You can look at the latest published artifacts on
 [`cloudevents-api`]: https://github.com/cloudevents/sdk-java/tree/main/api
 [`cloudevents-bom`]: https://github.com/cloudevents/sdk-java/tree/main/bom
 [`cloudevents-core`]: https://github.com/cloudevents/sdk-java/tree/main/core
+[`cloudevents-avro`]: https://github.com/cloudevents/sdk-java/tree/main/formats/avro
 [`cloudevents-json-jackson`]: https://github.com/cloudevents/sdk-java/tree/main/formats/json-jackson
 [`cloudevents-protobuf`]: https://github.com/cloudevents/sdk-java/tree/main/formats/protobuf
 [`cloudevents-xml`]: https://github.com/cloudevents/sdk-java/tree/main/formats/xml

--- a/formats/avro/README.md
+++ b/formats/avro/README.md
@@ -1,0 +1,9 @@
+# CloudEvents Avro Format
+
+This project provides functionality for the Java SDK to handle the
+[avro format](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/avro-format.md).
+
+The Avro definition file is located in src/main/avro/spec.proto. The file was directly
+copied from [https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/cloudevents.avsc]().
+
+The namespace has been changed so it does not clash  with the core namespace.

--- a/formats/avro/pom.xml
+++ b/formats/avro/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021-Present The CloudEvents Authors
+  ~ <p>
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ <p>
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ <p>
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.cloudevents</groupId>
+        <artifactId>cloudevents-parent</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>cloudevents-avro</artifactId>
+    <name>CloudEvents - Avro</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <version>1.11.1</version>
+                <configuration>
+                    <stringType>String</stringType>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.11.1</version>
+        </dependency>
+
+        <!-- Test deps -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.36</version>
+            <scope>test
+            </scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/formats/avro/src/main/avro/cloudevents.avsc
+++ b/formats/avro/src/main/avro/cloudevents.avsc
@@ -45,7 +45,10 @@
       "name": "time",
       "type": [
         "null",
-        "long"
+        {
+            "type": "long",
+            "logicalType": "timestamp-millis"
+        }
       ],
       "default": null
     },
@@ -60,56 +63,14 @@
           "string",
           "bytes"
         ]
-      }
+      },
+        "default": {}
     },
     {
       "name": "data",
       "type": [
         "bytes",
-        "null",
-        "boolean",
-        {
-          "type": "map",
-          "values": [
-            "null",
-            "boolean",
-            {
-              "type": "record",
-              "name": "CloudEventData",
-              "doc": "Representation of a JSON Value",
-              "fields": [
-                {
-                  "name": "value",
-                  "type": {
-                    "type": "map",
-                    "values": [
-                      "null",
-                      "boolean",
-                      {
-                        "type": "map",
-                        "values": "CloudEventData"
-                      },
-                      {
-                        "type": "array",
-                        "items": "CloudEventData"
-                      },
-                      "double",
-                      "string"
-                    ]
-                  }
-                }
-              ]
-            },
-            "double",
-            "string"
-          ]
-        },
-        {
-          "type": "array",
-          "items": "CloudEventData"
-        },
-        "double",
-        "string"
+        "null"
       ],
       "default": "null"
     }

--- a/formats/avro/src/main/avro/cloudevents.avsc
+++ b/formats/avro/src/main/avro/cloudevents.avsc
@@ -5,6 +5,34 @@
   "version": "1.0",
   "doc": "Avro Event Format for CloudEvents",
   "fields": [
+   {
+      "name": "id",
+      "type": "string"
+    },
+    {
+      "name": "source",
+      "type": "string"
+    },
+    {
+      "name": "type",
+      "type": "string"
+    },
+    {
+      "name": "datacontenttype",
+      "type": ["null", "string"]
+    },
+    {
+      "name": "dataschema",
+      "type": ["null", "string"]
+    },
+    {
+      "name": "subject",
+      "type": ["null", "string"]
+    },
+    {
+      "name": "time",
+      "type": ["null", "string"]
+    },
     {
       "name": "attribute",
       "type": {

--- a/formats/avro/src/main/avro/cloudevents.avsc
+++ b/formats/avro/src/main/avro/cloudevents.avsc
@@ -5,7 +5,7 @@
   "version": "1.0",
   "doc": "Avro Event Format for CloudEvents",
   "fields": [
-   {
+    {
       "name": "id",
       "type": "string"
     },
@@ -19,19 +19,35 @@
     },
     {
       "name": "datacontenttype",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     },
     {
       "name": "dataschema",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     },
     {
       "name": "subject",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     },
     {
       "name": "time",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "long"
+      ],
+      "default": null
     },
     {
       "name": "attribute",

--- a/formats/avro/src/main/avro/cloudevents.avsc
+++ b/formats/avro/src/main/avro/cloudevents.avsc
@@ -1,0 +1,73 @@
+{
+  "namespace": "io.cloudevents.v1.avro",
+  "type": "record",
+  "name": "CloudEvent",
+  "version": "1.0",
+  "doc": "Avro Event Format for CloudEvents",
+  "fields": [
+    {
+      "name": "attribute",
+      "type": {
+        "type": "map",
+        "values": [
+          "null",
+          "boolean",
+          "int",
+          "string",
+          "bytes"
+        ]
+      }
+    },
+    {
+      "name": "data",
+      "type": [
+        "bytes",
+        "null",
+        "boolean",
+        {
+          "type": "map",
+          "values": [
+            "null",
+            "boolean",
+            {
+              "type": "record",
+              "name": "CloudEventData",
+              "doc": "Representation of a JSON Value",
+              "fields": [
+                {
+                  "name": "value",
+                  "type": {
+                    "type": "map",
+                    "values": [
+                      "null",
+                      "boolean",
+                      {
+                        "type": "map",
+                        "values": "CloudEventData"
+                      },
+                      {
+                        "type": "array",
+                        "items": "CloudEventData"
+                      },
+                      "double",
+                      "string"
+                    ]
+                  }
+                }
+              ]
+            },
+            "double",
+            "string"
+          ]
+        },
+        {
+          "type": "array",
+          "items": "CloudEventData"
+        },
+        "double",
+        "string"
+      ],
+      "default": "null"
+    }
+  ]
+}

--- a/formats/avro/src/main/java/io/cloudevents/avro/AvroFormat.java
+++ b/formats/avro/src/main/java/io/cloudevents/avro/AvroFormat.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.cloudevents.avro;
+
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.data.BytesCloudEventData;
+import io.cloudevents.core.format.EventDeserializationException;
+import io.cloudevents.core.format.EventFormat;
+import io.cloudevents.core.format.EventSerializationException;
+import io.cloudevents.core.v1.CloudEventV1;
+import io.cloudevents.rw.CloudEventDataMapper;
+import io.cloudevents.types.Time;
+import io.cloudevents.v1.avro.CloudEvent.Builder;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An implementation of {@link EventFormat} for <a href="github.com/cloudevents/spec/blob/v1.0.1/avro-format">the Avro format</a>.
+ * This format is resolvable with {@link io.cloudevents.core.provider.EventFormatProvider} using the content type {@link #AVRO_CONTENT_TYPE}.
+ * It only supports data that is bytes.
+ */
+public class AvroFormat implements EventFormat {
+
+  public static final String AVRO_CONTENT_TYPE = "application/cloudevents+avro";
+
+  @Override
+  public byte[] serialize(CloudEvent ce) throws EventSerializationException {
+    try {
+      Builder builder;
+      builder = io.cloudevents.v1.avro.CloudEvent.newBuilder();
+
+      Map<String, Object> attribute = new HashMap<String,Object>() {
+        @Override
+        public Object put(String key, Object value) {
+          if (value instanceof Boolean || value instanceof Integer || value instanceof String)
+            return super.put(key, value);
+          else if (value instanceof byte[])
+            return super.put(key, ByteBuffer.wrap((byte[]) value));
+          else
+            // we cannot serialize this attribute because Avro schema does not support it
+            throw new IllegalStateException(String.format("unsupported attribute class %s of class %s", key, value.getClass()));
+        }
+      };
+
+      // mandatory
+      attribute.put(CloudEventV1.SPECVERSION, ce.getSpecVersion().toString());
+      attribute.put(CloudEventV1.SOURCE, ce.getSource().toString());
+      attribute.put(CloudEventV1.TYPE, ce.getType());
+      attribute.put(CloudEventV1.ID, ce.getId());
+
+      // optional
+      if (ce.getTime() != null)
+        attribute.put(CloudEventV1.TIME, Time.writeTime(ce.getTime()));
+      if (ce.getSubject() != null)
+        attribute.put(CloudEventV1.SUBJECT, ce.getSubject());
+      if (ce.getDataContentType() != null)
+        attribute.put(CloudEventV1.DATACONTENTTYPE, ce.getDataContentType());
+      if (ce.getDataSchema() != null)
+        attribute.put(CloudEventV1.DATASCHEMA, ce.getDataSchema().toString());
+
+      // extensions
+      for (String name : ce.getExtensionNames()) {
+        attribute.put(name, ce.getExtension(name));
+      }
+
+      builder.setAttribute(attribute);
+
+      CloudEventData data = ce.getData();
+      if (data != null) {
+        builder.setData(ByteBuffer.wrap(data.toBytes()));
+      }
+      return builder.build().toByteBuffer().array();
+    } catch (Exception e) {
+      throw new EventSerializationException(e);
+    }
+  }
+
+  @Override
+  public CloudEvent deserialize(byte[] bytes, CloudEventDataMapper<? extends CloudEventData> mapper)
+          throws EventDeserializationException {
+    try {
+      io.cloudevents.v1.avro.CloudEvent avroCe = io.cloudevents.v1.avro.CloudEvent.fromByteBuffer(ByteBuffer.wrap(bytes));
+      CloudEventBuilder builder = CloudEventBuilder.fromSpecVersion(SpecVersion.parse(avroCe.getAttribute().get(CloudEventV1.SPECVERSION).toString()));
+
+      // attributes + extensions
+      for (Map.Entry<String, Object> entry : avroCe.getAttribute().entrySet()) {
+        String name = entry.getKey();
+        Object value = entry.getValue();
+        switch (name) {
+          case CloudEventV1.SPECVERSION:
+            break;
+          case CloudEventV1.TYPE:
+            builder.withSource(URI.create((String) value));
+            break;
+          case CloudEventV1.SOURCE:
+            builder.withType((String) value);
+            break;
+          case CloudEventV1.ID:
+            builder.withId((String) value);
+            break;
+          case CloudEventV1.TIME:
+            builder.withTime(Time.parseTime((String) value));
+            break;
+          case CloudEventV1.SUBJECT:
+            builder.withSubject((String) value);
+            break;
+          case CloudEventV1.DATACONTENTTYPE:
+            builder.withDataContentType((String) value);
+            break;
+          case CloudEventV1.DATASCHEMA:
+            builder.withDataSchema(URI.create((String) value));
+            break;
+          default:
+            // must be an extension
+            // Avro supports boolean, int, string, bytes
+            if (value instanceof Boolean)
+              builder.withExtension(name, (boolean) value);
+            else if (value instanceof Integer)
+              builder.withExtension(name, (int) value);
+           else if (value instanceof String)
+              builder.withExtension(name, (String) value);
+            else if (value instanceof ByteBuffer)
+              builder.withExtension(name, ((ByteBuffer) value).array());
+            else
+              // this cannot happen, if ever seen, must be bug in this library
+              throw new AssertionError(String.format("invalid extension %s unsupported type %s", name, value.getClass()));
+        }
+      }
+
+      if (avroCe.getData() == null)
+        return builder.end();
+      if (avroCe.getData() instanceof ByteBuffer) {
+        CloudEventData data = BytesCloudEventData.wrap(((ByteBuffer) avroCe.getData()).array());
+        return builder.end(mapper.map(data));
+      } else
+        // this will be the JSON case, we don't support this yet, because it is "bottom left quadrant", i.e. low benefit, high cost
+        throw new IllegalStateException(String.format("unsupported data class %s", avroCe.getData().getClass()));
+    } catch (Exception e) {
+      throw new EventDeserializationException(e);
+    }
+  }
+
+  @Override
+  public String serializedContentType() {
+    return AVRO_CONTENT_TYPE;
+  }
+}

--- a/formats/avro/src/main/java/io/cloudevents/avro/AvroFormat.java
+++ b/formats/avro/src/main/java/io/cloudevents/avro/AvroFormat.java
@@ -32,6 +32,8 @@ import io.cloudevents.v1.avro.CloudEvent.Builder;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,7 +66,7 @@ public class AvroFormat implements EventFormat {
               .setAttribute(attribute);
 
       if (ce.getTime() != null)
-        builder.setTime(Time.writeTime(ce.getTime()));
+        builder.setTime(ce.getTime().toInstant().toEpochMilli());
       if (ce.getDataSchema() != null)
         builder.setDataschema(ce.getDataSchema().toString());
 
@@ -89,7 +91,7 @@ public class AvroFormat implements EventFormat {
               .withDataContentType(avroCe.getDatacontenttype());
 
       if (avroCe.getTime() != null)
-        builder.withTime(Time.parseTime(avroCe.getTime()));
+        builder.withTime(Instant.ofEpochMilli(avroCe.getTime()).atOffset(ZoneOffset.UTC));
       if (avroCe.getDataschema() != null)
         builder.withDataSchema(URI.create(avroCe.getDataschema()));
 

--- a/formats/avro/src/main/resources/META-INF/services/io.cloudevents.core.format.EventFormat
+++ b/formats/avro/src/main/resources/META-INF/services/io.cloudevents.core.format.EventFormat
@@ -1,0 +1,1 @@
+io.cloudevents.avro.AvroFormat

--- a/formats/avro/src/test/java/io/cloudevents/avro/AvroFormatTest.java
+++ b/formats/avro/src/test/java/io/cloudevents/avro/AvroFormatTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.cloudevents.avro;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.data.BytesCloudEventData;
+import io.cloudevents.core.data.PojoCloudEventData;
+import io.cloudevents.core.format.EventFormat;
+import io.cloudevents.core.provider.EventFormatProvider;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class AvroFormatTest {
+
+  private final EventFormat format = EventFormatProvider.getInstance().resolveFormat(AvroFormat.AVRO_CONTENT_TYPE);
+
+  // TODO - add test cases for
+  // - null data
+  // - non-bytes data
+  // - extension that is bytes
+  // - invalid extension type
+  @Test
+  void format() {
+    assertNotNull(format);
+    assertEquals(Collections.singleton("application/cloudevents+avro"), format.deserializableContentTypes());
+
+    CloudEvent event = CloudEventBuilder.v1()
+            // mandatory
+            .withId("")
+            .withSource(URI.create(""))
+            .withType("")
+            // optional
+            .withTime(OffsetDateTime.MIN)
+            .withSubject("")
+            .withDataSchema(URI.create(""))
+            // extension
+            // support boolean, int, string, bytes
+            .withExtension("boolean", false)
+            .withExtension("int", 0)
+            .withExtension("string", "")
+            // omitting bytes, because it is not supported be CloudEvent.equals
+            .withData("", BytesCloudEventData.wrap(new byte[0]))
+            .build();
+
+    byte[] serialized = format.serialize(event);
+
+    assertNotNull(serialized);
+
+    CloudEvent deserialized = format.deserialize(serialized);
+
+    assertEquals(event, deserialized);
+
+  }
+}

--- a/formats/avro/src/test/java/io/cloudevents/avro/AvroFormatTest.java
+++ b/formats/avro/src/test/java/io/cloudevents/avro/AvroFormatTest.java
@@ -25,7 +25,9 @@ import io.cloudevents.core.provider.EventFormatProvider;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,7 +54,7 @@ class AvroFormatTest {
             .withSource(URI.create(""))
             .withType("")
             // optional
-            .withTime(OffsetDateTime.MIN)
+            .withTime(Instant.EPOCH.atOffset(ZoneOffset.UTC))
             .withSubject("")
             .withDataSchema(URI.create(""))
             // extension

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <modules>
         <module>api</module>
         <module>core</module>
+        <module>formats/avro</module>
         <module>formats/json-jackson</module>
         <module>formats/protobuf</module>
         <module>formats/xml</module>


### PR DESCRIPTION
This is an intentionally hyper-concise implementation of Avro. It is 168 LOC (Protobuf is 699 LOC, 4x that).

Less code is less bugs.

Does not support map/boolean data. Why? See code.