### PR TITLE
feat: Add full Java module descriptors

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -13,27 +13,31 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 11, 17, 21 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          cache: 'maven'
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       - run: |
-          ./mvnw clean install -DskipTests -B
-          ./mvnw verify -B
+          ./mvnw -ntp -B clean install -DskipTests
+          ./mvnw -ntp -B verify
 
   deploy:
     runs-on: ubuntu-latest
     name: Deploy
     needs: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          cache: 'maven'
+          java-version: 11
+          distribution: 'temurin'
           server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username in deploy
           server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -13,13 +13,15 @@ jobs:
     env:
       NEW_VERSION: ${{ github.event.inputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          cache: 'maven'
+          java-version: 11
+          distribution: 'temurin'
       - name: Bump version using Maven
-        run: './mvnw versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -B'
+        run: './mvnw -ntp -B versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false'
       - name: Bump version in docs
         if: ${{ !endsWith(github.event.inputs.version, 'SNAPSHOT') }}
         run: 'find . -type f -name "*.md" -exec sed -i -e "s+<version>[a-zA-Z0-9.-]*<\/version>+<version>$NEW_VERSION</version>+g" {} +'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 11, 17, 21 ]
     name: Java ${{ matrix.java }} Test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           cache: 'maven'
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - run: |
-          ./mvnw clean install -DskipTests -B
-          ./mvnw verify -B
-          ./mvnw javadoc:javadoc
+          ./mvnw -ntp -B clean install -DskipTests
+          ./mvnw -ntp -B verify
+          ./mvnw -ntp -B javadoc:javadoc

--- a/amqp/pom.xml
+++ b/amqp/pom.xml
@@ -61,4 +61,12 @@
 
 	</dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -56,4 +56,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -83,7 +83,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
                 <configuration>
                     <compilerVersion>${javac.target}</compilerVersion>
                     <source>${javac.target}</source>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -83,7 +83,7 @@
             </dependency>
             <dependency>
                 <groupId>io.cloudevents</groupId>
-                <artifactId>io.cloudevents.sql</artifactId>
+                <artifactId>cloudevents-sql</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -67,6 +67,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>

--- a/formats/json-jackson/pom.xml
+++ b/formats/json-jackson/pom.xml
@@ -90,4 +90,13 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/formats/protobuf/pom.xml
+++ b/formats/protobuf/pom.xml
@@ -61,6 +61,10 @@
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -126,5 +130,4 @@
         </dependency>
 
     </dependencies>
-
 </project>

--- a/formats/xml/pom.xml
+++ b/formats/xml/pom.xml
@@ -84,4 +84,12 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/http/basic/pom.xml
+++ b/http/basic/pom.xml
@@ -63,4 +63,13 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/http/restful-ws-jakarta/pom.xml
+++ b/http/restful-ws-jakarta/pom.xml
@@ -91,6 +91,10 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/http/vertx/pom.xml
+++ b/http/vertx/pom.xml
@@ -87,4 +87,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -76,5 +76,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Maven plugins -->
@@ -125,6 +126,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.12.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <configuration>
                         <archive>
@@ -133,6 +139,36 @@
                             </manifestEntries>
                         </archive>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.moditect</groupId>
+                    <artifactId>moditect-maven-plugin</artifactId>
+                    <version>1.0.0.Final</version>
+                    <executions>
+                        <execution>
+                            <id>add-module-infos</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>add-module-info</goal>
+                            </goals>
+                            <configuration>
+                                <overwriteExistingFiles>true</overwriteExistingFiles>
+                                <failOnWarning>false</failOnWarning>
+                                <module>
+                                    <moduleInfo>
+                                        <name>${module-name}</name>
+                                        <!-- export everything -->
+                                        <exports>*;</exports>
+                                        <!-- declare services consumed by the artifact -->
+                                        <addServiceUses>true</addServiceUses>
+                                    </moduleInfo>
+                                </module>
+                                <jdepsExtraArgs>
+                                    <arg>--multi-release=9</arg>
+                                </jdepsExtraArgs>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.ec4j.maven</groupId>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -87,6 +87,10 @@
                     <listener>true</listener> <!-- TODO do we need the listener? -->
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Fixes #555 

The following modules have been left as automatic

 - restful-ws
 - spring
 - rocketmq

Because of the following issues:

```
Execution add-module-infos of goal org.moditect:moditect-maven-plugin:1.0.0.Final:add-module-info failed: Module java.xml.bind not found, required by java.ws.rs
```

```
Error: Module rocketmq.client.java contains package javax.annotation, module annotations.api exports package javax.annotation to rocketmq.client.java
```

```
Error: Modules java.annotation and jsr305 export package javax.annotation to module spring.webmvc
```