### PR TITLE
feat: JSON format to assume JSON content-type where possible

### DIFF
--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormat.java
@@ -213,7 +213,7 @@ public final class JsonFormat implements EventFormat {
         ceModule.addSerializer(CloudEvent.class, new CloudEventSerializer(
             options.isForceDataBase64Serialization(), options.isForceStringSerialization()));
         ceModule.addDeserializer(CloudEvent.class, new CloudEventDeserializer(
-            options.isForceExtensionNameLowerCaseDeserialization(), options.isForceIgnoreInvalidExtensionNameDeserialization()));
+            options.isForceExtensionNameLowerCaseDeserialization(), options.isForceIgnoreInvalidExtensionNameDeserialization(), options.isDataContentTypeDefaultingDisabled()));
         return ceModule;
     }
 

--- a/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormatOptions.java
+++ b/formats/json-jackson/src/main/java/io/cloudevents/jackson/JsonFormatOptions.java
@@ -21,24 +21,27 @@ public final class JsonFormatOptions {
     private final boolean forceStringSerialization;
     private final boolean forceExtensionNameLowerCaseDeserialization;
     private final boolean forceIgnoreInvalidExtensionNameDeserialization;
+    private final boolean disableDataContentTypeDefaulting;
 
     /**
      * Create a new instance of this class options the serialization / deserialization.
      */
     public JsonFormatOptions() {
-        this(false, false, false, false);
+        this(false, false, false, false, false);
     }
 
     JsonFormatOptions(
         boolean forceDataBase64Serialization,
         boolean forceStringSerialization,
         boolean forceExtensionNameLowerCaseDeserialization,
-        boolean forceIgnoreInvalidExtensionNameDeserialization
+        boolean forceIgnoreInvalidExtensionNameDeserialization,
+        boolean disableDataContentTypeDefaulting
     ) {
         this.forceDataBase64Serialization = forceDataBase64Serialization;
         this.forceStringSerialization = forceStringSerialization;
         this.forceExtensionNameLowerCaseDeserialization = forceExtensionNameLowerCaseDeserialization;
         this.forceIgnoreInvalidExtensionNameDeserialization = forceIgnoreInvalidExtensionNameDeserialization;
+        this.disableDataContentTypeDefaulting = disableDataContentTypeDefaulting;
     }
 
     public static JsonFormatOptionsBuilder builder() {
@@ -61,11 +64,14 @@ public final class JsonFormatOptions {
         return this.forceIgnoreInvalidExtensionNameDeserialization;
     }
 
+    public boolean isDataContentTypeDefaultingDisabled() { return this.disableDataContentTypeDefaulting; }
+
     public static class JsonFormatOptionsBuilder {
         private boolean forceDataBase64Serialization = false;
         private boolean forceStringSerialization = false;
         private boolean forceExtensionNameLowerCaseDeserialization = false;
         private boolean forceIgnoreInvalidExtensionNameDeserialization = false;
+        private boolean disableDataContentTypeDefaulting = false;
 
         public JsonFormatOptionsBuilder forceDataBase64Serialization(boolean forceDataBase64Serialization) {
             this.forceDataBase64Serialization = forceDataBase64Serialization;
@@ -87,12 +93,18 @@ public final class JsonFormatOptions {
             return this;
         }
 
+        public JsonFormatOptionsBuilder disableDataContentTypeDefaulting(boolean disableDataContentTypeDefaulting) {
+            this.disableDataContentTypeDefaulting = disableDataContentTypeDefaulting;
+            return this;
+        }
+
         public JsonFormatOptions build() {
             return new JsonFormatOptions(
                 this.forceDataBase64Serialization,
                 this.forceStringSerialization,
                 this.forceExtensionNameLowerCaseDeserialization,
-                this.forceIgnoreInvalidExtensionNameDeserialization
+                this.forceIgnoreInvalidExtensionNameDeserialization,
+                this.disableDataContentTypeDefaulting
             );
         }
     }

--- a/formats/json-jackson/src/test/java/io/cloudevents/jackson/CloudEventDeserializerTest.java
+++ b/formats/json-jackson/src/test/java/io/cloudevents/jackson/CloudEventDeserializerTest.java
@@ -1,0 +1,69 @@
+package io.cloudevents.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.cloudevents.CloudEvent;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import static io.cloudevents.jackson.JsonFormat.getCloudEventJacksonModule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CloudEventDeserializerTest {
+
+    private static final String nonBinaryPayload = "{\n" +
+        "    \"specversion\" : \"1.0\",\n" +
+        "    \"type\" : \"com.example.someevent\",\n" +
+        "    \"source\" : \"/mycontext\",\n" +
+        "    \"subject\": null,\n" +
+        "    \"id\" : \"D234-1234-1234\",\n" +
+        "    \"time\" : \"2018-04-05T17:31:00Z\",\n" +
+        "    \"comexampleextension1\" : \"value\",\n" +
+        "    \"comexampleothervalue\" : 5,\n" +
+        "    \"data\" : \"I'm just a string\"\n" +
+        "}";
+
+    private static final String binaryPayload = "{\n" +
+        "    \"specversion\" : \"1.0\",\n" +
+        "    \"type\" : \"com.example.someevent\",\n" +
+        "    \"source\" : \"/mycontext\",\n" +
+        "    \"id\" : \"D234-1234-1234\",\n" +
+        "    \"data_base64\" : \"eyAieHl6IjogMTIzIH0=\"\n" +
+        "}";
+
+    @Test
+    void impliedDataContentTypeNonBinaryData() throws IOException {
+        ObjectMapper mapper = getObjectMapper(false);
+        StringReader reader = new StringReader(nonBinaryPayload);
+        CloudEvent ce = mapper.readValue(reader, CloudEvent.class);
+        assertThat(ce.getDataContentType()).isEqualTo("application/json");
+
+        mapper = getObjectMapper(true);
+        reader = new StringReader(nonBinaryPayload);
+        ce = mapper.readValue(reader, CloudEvent.class);
+        assertThat(ce.getDataContentType()).isNull();
+    }
+
+    @Test
+    void impliedDataContentTypeBinaryData() throws IOException {
+        final ObjectMapper mapper = getObjectMapper(false);
+        StringReader reader = new StringReader(binaryPayload);
+        CloudEvent ce = mapper.readValue(reader, CloudEvent.class);
+        assertThat(ce.getDataContentType()).isNull();
+    }
+
+    private static ObjectMapper getObjectMapper(boolean disableDataContentTypeDefaulting) {
+        final ObjectMapper mapper = new ObjectMapper();
+        final SimpleModule module = getCloudEventJacksonModule(
+            JsonFormatOptions
+                .builder()
+                .disableDataContentTypeDefaulting(disableDataContentTypeDefaulting)
+                .build()
+        );
+        mapper.registerModule(module);
+        return mapper;
+    }
+
+}


### PR DESCRIPTION
For JSON structured CE we may assume JSON `datacontenttype` as long as `data` is present int the CE.