### PR TITLE
fix: invalid automatic module name

### DIFF
--- a/examples/amqp-proton/pom.xml
+++ b/examples/amqp-proton/pom.xml
@@ -10,7 +10,8 @@
   <artifactId>cloudevents-amqp-proton-example</artifactId>
 
 	<properties>
-       <vertx.version>4.0.0.Beta1</vertx.version>
+      <module-name>cloudevents.example.amqp.proton</module-name>
+      <vertx.version>4.0.0.Beta1</vertx.version>
 	</properties>
   <dependencies>
   	 <dependency>

--- a/examples/basic-http/pom.xml
+++ b/examples/basic-http/pom.xml
@@ -26,6 +26,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevents-basic-http-example</artifactId>
+    <properties>
+        <module-name>cloudevents.example.basic.http</module-name>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -10,6 +10,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevents-kafka-example</artifactId>
+    <properties>
+        <module-name>cloudevents.example.kafka</module-name>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/examples/restful-ws-microprofile-liberty/pom.xml
+++ b/examples/restful-ws-microprofile-liberty/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <openliberty.maven.version>3.5.1</openliberty.maven.version>
         <app.name>cloudevents-microprofile</app.name>
+        <module-name>cloudevents.example.restful.ws.microprofile.liberty</module-name>
 
         <!-- Liberty server properties -->
         <final.name>cloudeventsServer</final.name>

--- a/examples/restful-ws-quarkus/pom.xml
+++ b/examples/restful-ws-quarkus/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cloudevents-restful-ws-quarkus-example</artifactId>
     <properties>
+        <module-name>cloudevents.example.restful.ws.quarkus</module-name>
         <quarkus-plugin.version>1.10.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/examples/restful-ws-spring-boot/pom.xml
+++ b/examples/restful-ws-spring-boot/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>cloudevents-spring-boot-example</artifactId>
 
     <properties>
+        <module-name>cloudevents.example.spring.boot</module-name>
         <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
         <spring.version>5.2.9.RELEASE</spring.version>
     </properties>

--- a/examples/rocketmq/pom.xml
+++ b/examples/rocketmq/pom.xml
@@ -10,6 +10,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevents-rocketmq-example</artifactId>
+    <properties>
+        <module-name>cloudevents.example.rocketmq</module-name>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/examples/spring-function/pom.xml
+++ b/examples/spring-function/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>cloudevents-spring-function-example</artifactId>
 
     <properties>
+        <module-name>cloudevents.example.spring.function</module-name>
         <spring-boot.version>2.4.3</spring-boot.version>
     </properties>
 

--- a/examples/spring-reactive/pom.xml
+++ b/examples/spring-reactive/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>cloudevents-spring-reactive-example</artifactId>
 
     <properties>
+        <module-name>cloudevents.example.spring.reactive</module-name>
         <spring-boot.version>2.4.3</spring-boot.version>
     </properties>
 

--- a/examples/spring-rsocket/pom.xml
+++ b/examples/spring-rsocket/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>cloudevents-spring-rsocket-example</artifactId>
 
     <properties>
+        <module-name>cloudevents.example.spring.rsocket</module-name>
         <spring-boot.version>2.4.3</spring-boot.version>
     </properties>
 

--- a/examples/vertx/pom.xml
+++ b/examples/vertx/pom.xml
@@ -10,6 +10,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevents-vertx-example</artifactId>
+    <properties>
+        <module-name>cloudevents.example.vertx</module-name>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/http/restful-ws-integration-tests/restful-ws-common/pom.xml
+++ b/http/restful-ws-integration-tests/restful-ws-common/pom.xml
@@ -30,7 +30,9 @@
     <artifactId>cloudevents-http-restful-ws-integration-tests-common</artifactId>
     <name>CloudEvents - JAX-RS Integration Tests - Common</name>
     <packaging>jar</packaging>
-
+    <properties>
+        <module-name>io.cloudevents.jaxrs.integration.tests.common</module-name>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/http/restful-ws-integration-tests/restful-ws-jersey/pom.xml
+++ b/http/restful-ws-integration-tests/restful-ws-jersey/pom.xml
@@ -33,6 +33,7 @@
 
     <properties>
         <jersey.version>2.30.1</jersey.version>
+        <module-name>io.cloudevents.jaxrs.integration.tests.jersey</module-name>
     </properties>
 
     <dependencies>

--- a/http/restful-ws-integration-tests/restful-ws-resteasy/pom.xml
+++ b/http/restful-ws-integration-tests/restful-ws-resteasy/pom.xml
@@ -32,6 +32,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <module-name>io.cloudevents.jaxrs.integration.tests.resteasy</module-name>
         <vertx.version>3.9.2</vertx.version>
         <resteasy.version>4.5.6.Final</resteasy.version>
     </properties>

--- a/http/restful-ws-integration-tests/restful-ws-spring/pom.xml
+++ b/http/restful-ws-integration-tests/restful-ws-spring/pom.xml
@@ -32,6 +32,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <module-name>io.cloudevents.jaxrs.integration.tests.spring</module-name>
         <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
         <spring.version>5.2.9.RELEASE</spring.version>
     </properties>

--- a/http/restful-ws-jakarta-integration-tests/restful-ws-jakarta-common/pom.xml
+++ b/http/restful-ws-jakarta-integration-tests/restful-ws-jakarta-common/pom.xml
@@ -11,6 +11,10 @@
     <name>CloudEvents - JAX-RS Jakarta EE9+ Integration Tests - Common</name>
     <packaging>jar</packaging>
 
+	<properties>
+      <module-name>cloudevents.http.restful.ws.jakarta.integration.tests.common</module-name>
+	</properties>
+
     <dependencies>
         <dependency>
             <groupId>io.cloudevents</groupId>

--- a/http/restful-ws-jakarta-integration-tests/restful-ws-jersey/pom.xml
+++ b/http/restful-ws-jakarta-integration-tests/restful-ws-jersey/pom.xml
@@ -32,6 +32,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <module-name>cloudevents.http.restful.ws.jakarta.integration.tests.jersey</module-name>
         <jersey.version>3.0.8</jersey.version>
         <jakarta-ee.version>3.0.0</jakarta-ee.version>
     </properties>

--- a/http/restful-ws-jakarta-integration-tests/restful-ws-liberty/pom.xml
+++ b/http/restful-ws-jakarta-integration-tests/restful-ws-liberty/pom.xml
@@ -15,6 +15,8 @@
     <packaging>war</packaging>
 
     <properties>
+        <module-name>cloudevents.http.restful.ws.jakarta.integration.tests.microprofile</module-name>
+
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>

--- a/http/restful-ws-jakarta-integration-tests/restful-ws-resteasy/pom.xml
+++ b/http/restful-ws-jakarta-integration-tests/restful-ws-resteasy/pom.xml
@@ -14,6 +14,7 @@
 
 
     <properties>
+        <module-name>cloudevents.http.restful.ws.jakarta.integration.tests.resteasy</module-name>
         <vertx.version>4.3.3</vertx.version>
         <resteasy.version>6.0.3.Final</resteasy.version>
     </properties>


### PR DESCRIPTION
Inspired by [Automatic-Module-Name: Calling All Java Library Maintainers](https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers), I added the module names for the non-specified modules on their respective `pom.xml` file

Solves #638