### PR TITLE
Allow bumping versions in `/docs` only

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -5,6 +5,14 @@ on:
       version:
         description: 'Version to bump (without prepending "v")'
         required: true
+      maven-modules:
+        description: "Whether to bump versions in pom.xml files"
+        type: choice
+        required: true
+        default: 'true'
+        options:
+          - 'true'
+          - 'false'
 
 jobs:
   bump:
@@ -19,6 +27,7 @@ jobs:
         with:
           java-version: 8
       - name: Bump version using Maven
+        if: ${{ inputs.maven-modules == 'true' }}
         run: './mvnw versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -B'
       - name: Bump version in docs
         if: ${{ !endsWith(github.event.inputs.version, 'SNAPSHOT') }}


### PR DESCRIPTION
This will allow changing the version in the documentation website when a new release is published.