### PR TITLE
docs: correcting import to EventFormatProvider

### DIFF
--- a/docs/avro.md
+++ b/docs/avro.md
@@ -28,7 +28,7 @@ No further configuration is required is use the module.
 
 ```java
 import io.cloudevents.CloudEvent;
-import io.cloudevents.core.format.EventFormatProvider;
+import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.avro.avro.compact.AvroCompactFormat;
 

--- a/docs/core.md
+++ b/docs/core.md
@@ -87,7 +87,7 @@ with Jackson, add `cloudevents-json-jackson` as a dependency and then using the
 `EventFormatProvider`:
 
 ```java
-import io.cloudevents.core.format.EventFormatProvider;
+import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.jackson.JsonFormat;
 
 EventFormat format = EventFormatProvider

--- a/docs/json-jackson.md
+++ b/docs/json-jackson.md
@@ -29,7 +29,7 @@ adding the dependency to your project:
 ```java
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.format.ContentType;
-import io.cloudevents.core.format.EventFormatProvider;
+import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.core.builder.CloudEventBuilder;
 
 CloudEvent event = CloudEventBuilder.v1()

--- a/docs/protobuf.md
+++ b/docs/protobuf.md
@@ -31,7 +31,7 @@ No further configuration is required is use the module.
 ```java
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.format.ContentType;
-import io.cloudevents.core.format.EventFormatProvider;
+import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.core.builder.CloudEventBuilder;
 
 CloudEvent event = CloudEventBuilder.v1()

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -30,7 +30,7 @@ adding the dependency to your project:
 ```java
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.format.ContentType;
-import io.cloudevents.core.format.EventFormatProvider;
+import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.core.builder.CloudEventBuilder;
 
 CloudEvent event = CloudEventBuilder.v1()


### PR DESCRIPTION
The examples in the documentation imported `EventFormatProvider` from `io.cloudevents.core.format.EventFormatProvider`. This has been corrected to `io.cloudevents.core.provider.EventFormatProvider`.