### PR TITLE
Fix cloudevents-sql artifactId in bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -83,7 +83,7 @@
             </dependency>
             <dependency>
                 <groupId>io.cloudevents</groupId>
-                <artifactId>io.cloudevents.sql</artifactId>
+                <artifactId>cloudevents-sql</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Importing CE's BOM in Java project and then trying to use `cloudevents-sql` specifically as dependency results in `not found` error. Due to incorrect `artifactId` in BOM file itself. 

Also checking the managed deps in Maven Central, `io.cloudevents.sql` doesn't follow the convention. And visually it doesn't seem to be recognized and linked to artifact itself. 
https://mvnrepository.com/artifact/io.cloudevents/cloudevents-bom/4.0.1

This is artifact the BOM should be point at: https://mvnrepository.com/artifact/io.cloudevents/cloudevents-sql/4.0.1