### PR TITLE
fix: disallow empty 'subject' header

### DIFF
--- a/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/impl/BaseCloudEventBuilder.java
@@ -219,6 +219,10 @@ public abstract class BaseCloudEventBuilder<SELF extends BaseCloudEventBuilder<S
         return new IllegalStateException("Attribute '" + attributeName + "' cannot be null");
     }
 
+    protected static IllegalStateException createEmptyAttributeException(String attributeName) {
+        return new IllegalStateException("Attribute '" + attributeName + "' cannot be empty");
+    }
+
     /**
      * Validates the extension name as defined in  CloudEvents spec.
      *

--- a/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v03/CloudEventBuilder.java
@@ -124,6 +124,9 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
         if (type == null) {
             throw createMissingAttributeException("type");
         }
+        if (subject != null && subject.isEmpty()) {
+            throw createEmptyAttributeException(("subject"));
+        }
 
         CloudEventV03 cloudEvent = new CloudEventV03(id, source, type, time, schemaurl, datacontenttype, subject, this.data, this.extensions);
         final CloudEventValidatorProvider validator = CloudEventValidatorProvider.getInstance();

--- a/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
+++ b/core/src/main/java/io/cloudevents/core/v1/CloudEventBuilder.java
@@ -120,6 +120,9 @@ public final class CloudEventBuilder extends BaseCloudEventBuilder<CloudEventBui
         if (type == null) {
             throw createMissingAttributeException(TYPE);
         }
+        if (subject != null && subject.isEmpty()) {
+            throw createEmptyAttributeException(("subject"));
+        }
 
         CloudEvent cloudEvent = new CloudEventV1(id, source, type, datacontenttype, dataschema, subject, time, this.data, this.extensions);
 

--- a/core/src/test/java/io/cloudevents/core/v03/CloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/v03/CloudEventBuilderTest.java
@@ -158,4 +158,27 @@ public class CloudEventBuilderTest {
         ).hasMessageContaining("Attribute 'type' cannot be null");
     }
 
+    @Test
+    void testMissingSubject() {
+        CloudEvent actual = CloudEventBuilder
+            .v03()
+            .withId("000")
+            .withSource(URI.create("http://localhost"))
+            .withType(TYPE)
+            .build();
+
+        assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void testEmptySubject() {
+        assertThatCode(() -> CloudEventBuilder
+            .v03()
+            .withId("000")
+            .withSource(URI.create("http://localhost"))
+            .withType(TYPE)
+            .withSubject("")
+            .build()
+        ).hasMessageContaining("Attribute 'subject' cannot be empty");
+    }
 }

--- a/core/src/test/java/io/cloudevents/core/v1/CloudEventBuilderTest.java
+++ b/core/src/test/java/io/cloudevents/core/v1/CloudEventBuilderTest.java
@@ -154,4 +154,27 @@ public class CloudEventBuilderTest {
         ).hasMessageContaining("Expecting sales in namespace extension");
     }
 
+    @Test
+    void testMissingSubject() {
+        CloudEvent actual = CloudEventBuilder
+            .v1()
+            .withId("000")
+            .withSource(URI.create("http://localhost"))
+            .withType(TYPE)
+            .build();
+
+        assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void testEmptySubject() {
+        assertThatCode(() -> CloudEventBuilder
+            .v1()
+            .withId("000")
+            .withSource(URI.create("http://localhost"))
+            .withType(TYPE)
+            .withSubject("")
+            .build()
+        ).hasMessageContaining("Attribute 'subject' cannot be empty");
+    }
 }

--- a/formats/avro-compact/src/test/java/io/cloudevents/avro/compact/AvroCompactFormatTest.java
+++ b/formats/avro-compact/src/test/java/io/cloudevents/avro/compact/AvroCompactFormatTest.java
@@ -48,7 +48,7 @@ class AvroCompactFormatTest {
                 .withType("")
                 // optional
                 .withTime(Instant.EPOCH.atOffset(ZoneOffset.UTC))
-                .withSubject("")
+                .withSubject("subject")
                 .withDataSchema(URI.create(""))
                 // extension
                 // support boolean, int, long, string, bytes
@@ -71,7 +71,5 @@ class AvroCompactFormatTest {
         byte[] reserialized = format.serialize(deserialized);
 
         assertArrayEquals(serialized, reserialized);
-        
-
     }
 }


### PR DESCRIPTION
Specification clearly states that 'subject' is optional but if present, MUST be non-empty (spec at https://github.com/cloudevents/spec/blob/v1.0/spec.md#subject)

Fixes #676 