### PR TITLE
upgrade to protobuf sdk 4.31.1

### DIFF
--- a/formats/protobuf/pom.xml
+++ b/formats/protobuf/pom.xml
@@ -32,7 +32,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <protobuf.version>3.21.10</protobuf.version>
+        <protobuf.version>4.31.1</protobuf.version>
         <module-name>io.cloudevents.formats.protobuf</module-name>
     </properties>
 
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>com.google.truth.extensions</groupId>
             <artifactId>truth-proto-extension</artifactId>
-            <version>1.1.5</version>
+            <version>1.4.4</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Upgrade protobuf to 4.3.1. 
This is the latest version of protobuf, no changes for the wire format but the library is not compatible with 3.x so we might need a major release for it

https://github.com/cloudevents/sdk-java/issues/694