### PR TITLE
Deprecating to Jakarta EE 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,3 @@ _site/
 
 # MacOS
 *.DS_Store
-/http/restful-ws-jakarta/src/main/*
-

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Using the Java SDK you can:
 
 -   Access, create and manipulate `CloudEvent` inside your application.
 -   Serialize and deserialize `CloudEvent` back and forth using the _CloudEvents
-    Event Format_, like Json.
+    Event Format_, like JSON.
 -   Read and write `CloudEvent` back and forth to HTTP, Kafka, AMQP using the
     _CloudEvents Protocol Binding_ implementations we provide for a wide range
-    of well known Java frameworks/libraries.
+    of well-known Java frameworks/libraries.
 
 To check out the complete documentation and how to get started, look at the dedicated website
 https://cloudevents.github.io/sdk-java/.

--- a/README.md
+++ b/README.md
@@ -32,26 +32,27 @@ Stay tuned!
 
 Supported features of the specification:
 
-|                                         | [v0.3](https://github.com/cloudevents/spec/tree/v0.3) | [v1.0](https://github.com/cloudevents/spec/tree/v1.0) |
-| :-------------------------------------: | :---------------------------------------------------: | :---------------------------------------------------: |
-|            CloudEvents Core             |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|          AMQP Protocol Binding          |                          :x:                          |                          :x:                          |
-|            - [Proton](amqp)             |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|            AVRO Event Format            |                          :x:                          |                          :x:                          |
-|          HTTP Protocol Binding          |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|         - [Vert.x](http/vertx)          |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-| - [Jakarta Restful WS](http/restful-ws) |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|          - [Basic](http/basic)          |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|           - [Spring](spring)            |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|           - [http4k][http4k]<sup>†</sup>|                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|            JSON Event Format            |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|    - [Jackson](formats/json-jackson)    |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|            Protobuf Event Format        |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|            - [Proto](formats/protobuf)  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|     [Kafka Protocol Binding](kafka)     |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|          MQTT Protocol Binding          |                          :x:                          |                          :x:                          |
-|          NATS Protocol Binding          |                          :x:                          |                          :x:                          |
-|                Web hook                 |                          :x:                          |                          :x:                          |
+|                                                        | [v0.3](https://github.com/cloudevents/spec/tree/v0.3) | [v1.0](https://github.com/cloudevents/spec/tree/v1.0) |
+|:------------------------------------------------------:|:-----------------------------------------------------:|:-----------------------------------------------------:|
+|                    CloudEvents Core                    |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                 AMQP Protocol Binding                  |                          :x:                          |                          :x:                          |
+|                    - [Proton](amqp)                    |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                   AVRO Event Format                    |                          :x:                          |                          :x:                          |
+|                 HTTP Protocol Binding                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                 - [Vert.x](http/vertx)                 |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|      - [Jakarta EE 8 Restful WS](http/restful-ws)      |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+| - [Jakarta EE 9+ Restful WS](http/restful-ws-jakarta)  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                 - [Basic](http/basic)                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                   - [Spring](spring)                   |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|             - [http4k][http4k]<sup>†</sup>             |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                   JSON Event Format                    |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|           - [Jackson](formats/json-jackson)            |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                 Protobuf Event Format                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|              - [Proto](formats/protobuf)               |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|            [Kafka Protocol Binding](kafka)             |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                 MQTT Protocol Binding                  |                          :x:                          |                          :x:                          |
+|                 NATS Protocol Binding                  |                          :x:                          |                          :x:                          |
+|                        Web hook                        |                          :x:                          |                          :x:                          |
 
 <sub>† Source/artifacts hosted externally</sub>
 
@@ -69,6 +70,7 @@ Javadocs are available on [javadoc.io](https://www.javadoc.io):
 -   [cloudevents-xml](https://www.javadoc.io/doc/io.cloudevents/cloudevents-xml)
 -   [cloudevents-http-basic](https://www.javadoc.io/doc/io.cloudevents/cloudevents-http-basic)
 -   [cloudevents-http-restful-ws](https://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws)
+-   [cloudevents-http-restful-ws-jakarta](https://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws-jakarta)
 -   [cloudevents-http-vertx](https://www.javadoc.io/doc/io.cloudevents/cloudevents-http-vertx)
 -   [cloudevents-kafka](https://www.javadoc.io/doc/io.cloudevents/cloudevents-kafka)
 -   [cloudevents-amqp](https://www.javadoc.io/doc/io.cloudevents/cloudevents-amqp)

--- a/docs/http-basic.md
+++ b/docs/http-basic.md
@@ -13,6 +13,7 @@ There are also more specialized HTTP bindings:
 
 - [`cloudevents-http-vertx`](http-vertx.md)
 - [`cloudevents-http-restful-ws`](http-jakarta-restful-ws.md)
+- [`cloudevents-http-restful-ws-jakarta`](http-jakarta-restful-ws-jakarta.md)
 - [`cloudevents-spring`](spring.md)
 
 Since this module is generic it doesn't offer optimal performance for all HTTP

--- a/docs/http-basic.md
+++ b/docs/http-basic.md
@@ -12,7 +12,7 @@ This module is designed to be usable with various HTTP APIs.
 There are also more specialized HTTP bindings:
 
 - [`cloudevents-http-vertx`](http-vertx.md)
-- [`cloudevents-http-restful-ws`](http-jakarta-restful-ws.md)
+- [`cloudevents-http-restful-ws`](http-jakarta-restful-ws.md) (deprecated, please use `cloudevents-http-restful-ws-jakarta`)
 - [`cloudevents-http-restful-ws-jakarta`](http-jakarta-restful-ws-jakarta.md)
 - [`cloudevents-spring`](spring.md)
 

--- a/docs/http-basic.md
+++ b/docs/http-basic.md
@@ -16,12 +16,12 @@ There are also more specialized HTTP bindings:
 - [`cloudevents-http-restful-ws-jakarta`](http-jakarta-restful-ws-jakarta.md)
 - [`cloudevents-spring`](spring.md)
 
-Since this module is generic it doesn't offer optimal performance for all HTTP
+Since this module is generic, it doesn't offer optimal performance for all HTTP
 implementations. For better performance consider implementing `MessageReader`
 and `MessageWriter` that are tailored for specific HTTP implementation. As a
-reference you can take aforementioned existing bindings.
+reference, you can take the aforementioned existing bindings.
 
-For Maven based projects, use the following to configure the CloudEvents Generic
+For Maven-based projects, use the following to configure the CloudEvents Generic
 HTTP Transport:
 
 ```xml

--- a/docs/http-jakarta-restful-ws-jakarta.md
+++ b/docs/http-jakarta-restful-ws-jakarta.md
@@ -7,7 +7,7 @@ nav_order: 5
 
 [![Javadocs](https://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws-jakarta.svg?color=green)](https://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws-jakarta)
 
-For Maven based projects, use the following to configure the CloudEvents Jakarta
+For Maven-based projects, use the following to configure the CloudEvents Jakarta
 RESTful Web Services Binding for Jakarta EE 9+:
 
 ```xml
@@ -20,7 +20,7 @@ RESTful Web Services Binding for Jakarta EE 9+:
 
 This integration is tested with Jersey (Requires JDK11 or higher), RestEasy & Microprofile Liberty.
 
-#### * Before using this package ensure your web framework  does support the `jakarta.*` namespace.
+#### * Before using this package ensure your web framework does support the `jakarta.*` namespace.
 
 ## Receiving CloudEvents
 
@@ -40,8 +40,6 @@ import jakarta.ws.rs.core.Response;
 
 @Path("/")
 public class EventReceiverResource {
-
-
 
     @GET
     @Path("getMinEvent")

--- a/docs/http-jakarta-restful-ws-jakarta.md
+++ b/docs/http-jakarta-restful-ws-jakarta.md
@@ -5,7 +5,7 @@ nav_order: 5
 
 # HTTP Protocol Binding for Jakarta EE 9+ - Jakarta RESTful Web Services
 
-[![Javadocs](https://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws.svg?color=green)](https://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws)
+[![Javadocs](https://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws-jakarta.svg?color=green)](https://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws-jakarta)
 
 For Maven based projects, use the following to configure the CloudEvents Jakarta
 RESTful Web Services Binding for Jakarta EE 9+:

--- a/docs/http-jakarta-restful-ws.md
+++ b/docs/http-jakarta-restful-ws.md
@@ -3,7 +3,7 @@ title: CloudEvents HTTP Jakarta RESTful Web Services
 nav_order: 5
 ---
 
-# HTTP Protocol Binding for Jakarta EE8 - RESTful Web Services
+# HTTP Protocol Binding for Jakarta EE 8 - RESTful Web Services
 
 [![Javadocs](http://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws.svg?color=green)](http://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws)
 

--- a/docs/http-jakarta-restful-ws.md
+++ b/docs/http-jakarta-restful-ws.md
@@ -5,6 +5,9 @@ nav_order: 5
 
 # HTTP Protocol Binding for Jakarta EE 8 - RESTful Web Services
 
+This module is deprecated and will be removed in version 5.0.
+Please migrate to Jakarta EE 9+ and use the `cloudevents-http-restful-ws-jakarta` module instead.
+
 [![Javadocs](http://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws.svg?color=green)](http://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws)
 
 For Maven based projects, use the following to configure the CloudEvents Jakarta

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,10 +19,10 @@ Using the Java SDK you can:
 
 -   Access, create and manipulate `CloudEvent` inside your application.
 -   Serialize and deserialize `CloudEvent` back and forth using the _CloudEvents
-    Event Format_, like Json.
+    Event Format_, like JSON.
 -   Read and write `CloudEvent` back and forth to HTTP, Kafka, AMQP using the
     _CloudEvents Protocol Binding_ implementations we provide for a wide range
-    of well known Java frameworks/libraries.
+    of well-known Java frameworks/libraries.
 
 ## Supported features
 
@@ -104,7 +104,7 @@ a different feature from the different sub specs of
     [Vert.x Core](https://vertx.io/)
 -   [`cloudevents-http-restful-ws`] Implementation of [HTTP Protocol Binding]
     for [Jakarta EE 8 Restful WS](https://jakarta.ee/specifications/restful-ws/2.1/)
--   [`cloudevents-http-restful-ws-jakarta`] Implementation of  [HTTP Protocol Binding]
+-   [`cloudevents-http-restful-ws-jakarta`] Implementation of [HTTP Protocol Binding]
       for [Jakarta EE 9+ Restful WS](https://jakarta.ee/specifications/restful-ws/)
 -   [`cloudevents-http-basic`] Generic implementation of [HTTP Protocol
     Binding], primarily intended for integrators

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,28 +26,29 @@ Using the Java SDK you can:
 
 ## Supported features
 
-|                                                    | [v0.3](https://github.com/cloudevents/spec/tree/v0.3) | [v1.0](https://github.com/cloudevents/spec/tree/v1.0) |
-| :------------------------------------------------: | :---------------------------------------------------: | :---------------------------------------------------: |
-|                  CloudEvents Core                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|               AMQP Protocol Binding                |                          :x:                          |                          :x:                          |
-|             - [Proton](amqp-proton.md)             |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|                 AVRO Event Format                  |                          :x:                          |                          :x:                          |
-|               HTTP Protocol Binding                |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|             - [Vert.x](http-vertx.md)              |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-| - [Jakarta Restful WS](http-jakarta-restful-ws.md) |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|              - [Basic](http-basic.md)              |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|               - [Spring](spring.md)                |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|               - [http4k][http4k]<sup>†</sup>       |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|                 JSON Event Format                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|            - [Jackson](json-jackson.md)            |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|                Protobuf Event Format               |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|            - [Proto](protobuf.md)                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|                XML Event Format                    |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|            - [XML](xml.md)                         |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|         [Kafka Protocol Binding](kafka.md)         |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
-|               MQTT Protocol Binding                |                          :x:                          |                          :x:                          |
-|               NATS Protocol Binding                |                          :x:                          |                          :x:                          |
-|                      Web hook                      |                          :x:                          |                          :x:                          |
+|                                                                  | [v0.3](https://github.com/cloudevents/spec/tree/v0.3) | [v1.0](https://github.com/cloudevents/spec/tree/v1.0) |
+|:----------------------------------------------------------------:|:-----------------------------------------------------:|:-----------------------------------------------------:|
+|                         CloudEvents Core                         |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                      AMQP Protocol Binding                       |                          :x:                          |                          :x:                          |
+|                    - [Proton](amqp-proton.md)                    |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                        AVRO Event Format                         |                          :x:                          |                          :x:                          |
+|                      HTTP Protocol Binding                       |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                    - [Vert.x](http-vertx.md)                     |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|     - [Jakarta EE 8 Restful WS](http-jakarta-restful-ws.md)      |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+| - [Jakarta EE 9+ Restful WS](http-jakarta-restful-ws-jakarta.md) |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                     - [Basic](http-basic.md)                     |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                      - [Spring](spring.md)                       |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                  - [http4k][http4k]<sup>†</sup>                  |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                        JSON Event Format                         |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                   - [Jackson](json-jackson.md)                   |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                      Protobuf Event Format                       |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                      - [Proto](protobuf.md)                      |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                         XML Event Format                         |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                         - [XML](xml.md)                          |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                [Kafka Protocol Binding](kafka.md)                |                  :heavy_check_mark:                   |                  :heavy_check_mark:                   |
+|                      MQTT Protocol Binding                       |                          :x:                          |                          :x:                          |
+|                      NATS Protocol Binding                       |                          :x:                          |                          :x:                          |
+|                             Web hook                             |                          :x:                          |                          :x:                          |
 
 <sub>† Source/artifacts hosted externally</sub>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,7 +103,7 @@ a different feature from the different sub specs of
 -   [`cloudevents-http-vertx`] Implementation of [HTTP Protocol Binding] with
     [Vert.x Core](https://vertx.io/)
 -   [`cloudevents-http-restful-ws`] Implementation of [HTTP Protocol Binding]
-    for [Jakarta EE 8 Restful WS](https://jakarta.ee/specifications/restful-ws/2.1/)
+    for [Jakarta EE 8 Restful WS](https://jakarta.ee/specifications/restful-ws/2.1/) (deprecated, please use `cloudevents-http-restful-ws-jakarta`)
 -   [`cloudevents-http-restful-ws-jakarta`] Implementation of [HTTP Protocol Binding]
       for [Jakarta EE 9+ Restful WS](https://jakarta.ee/specifications/restful-ws/)
 -   [`cloudevents-http-basic`] Generic implementation of [HTTP Protocol

--- a/examples/restful-ws-microprofile-liberty/README.md
+++ b/examples/restful-ws-microprofile-liberty/README.md
@@ -4,7 +4,7 @@ This project uses Microprofile 5.0 with OpenLiberty
 
 If you would like to know more about Microprofile go to https://microprofile.io
 
-This Example uses Jakarta EE9 features as such the top level namespace of the `ws-api` packages has changed from `javax` to `jakarta` and uses the `cloudevents-http-restful-ws-jakarta` artifact.
+This Example uses Jakarta EE 9+ features as such the top level namespace of the `ws-api` packages has changed from `javax` to `jakarta` and uses the `cloudevents-http-restful-ws-jakarta` artifact.
 
 ## Build and Execution
 

--- a/http/restful-ws-jakarta-integration-tests/pom.xml
+++ b/http/restful-ws-jakarta-integration-tests/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevents-http-restful-ws-jakarta-integration-tests</artifactId>
-    <name>CloudEvents - JAX-RS Jakarta EE9+ Web Http Binding Integration Tests</name>
+    <name>CloudEvents - JAX-RS Jakarta EE 9+ Web Http Binding Integration Tests</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/http/restful-ws-jakarta-integration-tests/restful-ws-jakarta-common/pom.xml
+++ b/http/restful-ws-jakarta-integration-tests/restful-ws-jakarta-common/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cloudevents-http-restful-ws-jakarta-integration-tests-common</artifactId>
-    <name>CloudEvents - JAX-RS Jakarta EE9+ Integration Tests - Common</name>
+    <name>CloudEvents - JAX-RS Jakarta EE 9+ Integration Tests - Common</name>
     <packaging>jar</packaging>
 
 	<properties>

--- a/http/restful-ws-jakarta-integration-tests/restful-ws-jersey/pom.xml
+++ b/http/restful-ws-jakarta-integration-tests/restful-ws-jersey/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevents-http-restful-ws-jakarta-integration-tests-jersey</artifactId>
-    <name>CloudEvents - JAX-RS Jakarta EE9+ Integration Tests - Jersey</name>
+    <name>CloudEvents - JAX-RS Jakarta EE 9+ Integration Tests - Jersey</name>
     <packaging>jar</packaging>
 
     <properties>

--- a/http/restful-ws-jakarta-integration-tests/restful-ws-liberty/pom.xml
+++ b/http/restful-ws-jakarta-integration-tests/restful-ws-liberty/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevents-http-restful-ws-jakarta-integration-tests-microprofile</artifactId>
-    <name>CloudEvents - JAX-RS Jakarta EE9+ Integration Tests - Microprofile and Liberty</name>
+    <name>CloudEvents - JAX-RS Jakarta EE 9+ Integration Tests - Microprofile and Liberty</name>
     <packaging>war</packaging>
 
     <properties>

--- a/http/restful-ws-jakarta-integration-tests/restful-ws-resteasy/pom.xml
+++ b/http/restful-ws-jakarta-integration-tests/restful-ws-resteasy/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevents-http-restful-ws-jakarta-integration-tests-resteasy</artifactId>
-    <name>CloudEvents - JAX-RS Jakarta EE9+ Integration Tests - RESTEasy</name>
+    <name>CloudEvents - JAX-RS Jakarta EE 9+ Integration Tests - RESTEasy</name>
     <packaging>jar</packaging>
 
 

--- a/http/restful-ws-jakarta/README.md
+++ b/http/restful-ws-jakarta/README.md
@@ -1,4 +1,4 @@
-# HTTP Protocol Binding for Jakarta EE9+ - Jakarta RESTful Web Services
+# HTTP Protocol Binding for Jakarta EE 9+ - Jakarta RESTful Web Services
 
 Javadocs: [![Javadocs](http://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws-jakarta.svg?color=green)](http://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws-jakarta)
 

--- a/http/restful-ws-jakarta/README.md
+++ b/http/restful-ws-jakarta/README.md
@@ -3,5 +3,3 @@
 Javadocs: [![Javadocs](http://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws-jakarta.svg?color=green)](http://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws-jakarta)
 
 Documentation: https://cloudevents.github.io/sdk-java/http-jakarta-restful-ws-jakarta
-
-The code for this package lies within the [restful-ws](https://github.com/cloudevents/sdk-java/tree/main/http/restful-ws) directory and is copied within here and has `javax.` replaced with `jakarta.`

--- a/http/restful-ws-jakarta/README.md
+++ b/http/restful-ws-jakarta/README.md
@@ -1,7 +1,7 @@
 # HTTP Protocol Binding for Jakarta EE9+ - Jakarta RESTful Web Services
 
-Javadocs: [![Javadocs](http://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws.svg?color=green)](http://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws)
+Javadocs: [![Javadocs](http://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws-jakarta.svg?color=green)](http://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws-jakarta)
 
-Documentation: https://cloudevents.github.io/sdk-java/http-jakarta-restful-ws
+Documentation: https://cloudevents.github.io/sdk-java/http-jakarta-restful-ws-jakarta
 
 The code for this package lies within the [restful-ws](https://github.com/cloudevents/sdk-java/tree/main/http/restful-ws) directory and is copied within here and has `javax.` replaced with `jakarta.`

--- a/http/restful-ws-jakarta/pom.xml
+++ b/http/restful-ws-jakarta/pom.xml
@@ -61,37 +61,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources
-                        </phase>
-                        <configuration>
-                            <target>
-                                <delete dir="src/main"/>
-                                <copy todir="src">
-                                    <fileset dir="../restful-ws\src" />
-                                    <filterchain>
-                                        <replaceregex pattern="javax." replace="jakarta." />
-                                    </filterchain>
-                                </copy>
-                                <move todir="src/main/resources/META-INF/services">
-                                    <fileset dir="src/main/resources/META-INF/services" />
-                                    <mapper type="regexp" from="(.*)javax.(.*)" to="\1jakarta.\2"/>
-                                </move>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/BinaryEncoding.java
+++ b/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/BinaryEncoding.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.http.restful.ws;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate a method with this annotation to specify that you want to write the returned event
+ * in binary mode.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BinaryEncoding {
+}

--- a/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/CloudEventsProvider.java
+++ b/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/CloudEventsProvider.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.http.restful.ws;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.format.EventFormat;
+import io.cloudevents.core.message.MessageWriter;
+import io.cloudevents.core.provider.EventFormatProvider;
+import io.cloudevents.http.restful.ws.impl.RestfulWSClientMessageWriter;
+import io.cloudevents.http.restful.ws.impl.RestfulWSMessageFactory;
+import io.cloudevents.http.restful.ws.impl.RestfulWSMessageWriter;
+import io.cloudevents.rw.CloudEventWriter;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * This provider implements {@link CloudEvent} encoding and decoding for Jax-Rs Resources and with {@link jakarta.ws.rs.client.Client}.
+ */
+@Provider
+@Consumes(MediaType.WILDCARD)
+@Produces(MediaType.WILDCARD)
+public class CloudEventsProvider implements MessageBodyReader<CloudEvent>, MessageBodyWriter<CloudEvent>, ClientRequestFilter {
+
+    /**
+     * The content type to use when sending {@link CloudEvent} with {@link jakarta.ws.rs.client.Client}
+     */
+    public static MediaType CLOUDEVENT_TYPE = MediaType.valueOf("application/cloudevents");
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return CloudEvent.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public CloudEvent readFrom(Class<CloudEvent> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        return RestfulWSMessageFactory.create(mediaType, httpHeaders, bufferBodyInput(entityStream)).toEvent();
+    }
+
+    private byte[] bufferBodyInput(InputStream inputStream) throws IOException {
+        if (inputStream == null) {
+            return null;
+        }
+
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+        int nRead;
+        byte[] data = new byte[1024];
+        while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, nRead);
+        }
+
+        buffer.flush();
+        return buffer.toByteArray();
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return CloudEvent.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void writeTo(CloudEvent event, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        Optional<String> structuredEncodingFormat = Arrays
+            .stream(annotations)
+            .filter(a -> a.annotationType().equals(StructuredEncoding.class))
+            .map(a -> ((StructuredEncoding) a).value())
+            .findFirst();
+
+        if (structuredEncodingFormat.isPresent()) {
+            writeStructured(
+                event,
+                structuredEncodingFormat.get(),
+                new RestfulWSMessageWriter(httpHeaders, entityStream)
+            );
+        } else {
+            writeBinary(
+                event,
+                new RestfulWSMessageWriter(httpHeaders, entityStream)
+            );
+        }
+    }
+
+    private <V extends MessageWriter<V, Void> & CloudEventWriter<Void>> void writeBinary(CloudEvent input, V visitor) {
+        visitor.writeBinary(input);
+    }
+
+    private <V extends MessageWriter<V, Void> & CloudEventWriter<Void>> void writeStructured(CloudEvent input, EventFormat format, V visitor) {
+        visitor.writeStructured(input, format);
+    }
+
+    private <V extends MessageWriter<V, Void> & CloudEventWriter<Void>> void writeStructured(CloudEvent input, String formatString, V visitor) {
+        EventFormat format = EventFormatProvider.getInstance().resolveFormat(formatString);
+
+        if (format == null) {
+            throw new IllegalArgumentException("Cannot resolve format " + formatString);
+        }
+
+        writeStructured(input, format, visitor);
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        if (isCloudEventEntity(requestContext.getEntity())) {
+            EventFormat format = EventFormatProvider.getInstance().resolveFormat(requestContext.getMediaType().toString());
+
+            if (format != null) {
+                writeStructured(
+                    (CloudEvent) requestContext.getEntity(),
+                    format,
+                    new RestfulWSClientMessageWriter(requestContext)
+                );
+            } else {
+                writeBinary(
+                    (CloudEvent) requestContext.getEntity(),
+                    new RestfulWSClientMessageWriter(requestContext)
+                );
+            }
+        }
+    }
+
+    private static boolean isCloudEventEntity(Object obj) {
+        return obj != null && CloudEvent.class.isAssignableFrom(obj.getClass());
+    }
+
+}

--- a/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/StructuredEncoding.java
+++ b/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/StructuredEncoding.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.http.restful.ws;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate a method with this annotation to specify that you want to write the returned event
+ * in structured mode.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StructuredEncoding {
+    /**
+     * Specify the content type of the structured mode.
+     * This values will be used to resolve the {@link io.cloudevents.core.format.EventFormat} through
+     * the {@link io.cloudevents.core.provider.EventFormatProvider}.
+     */
+    String value();
+}

--- a/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
+++ b/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.http.restful.ws.impl;
+
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.data.BytesCloudEventData;
+import io.cloudevents.core.impl.StringUtils;
+import io.cloudevents.core.message.impl.BaseGenericBinaryMessageReaderImpl;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+import static io.cloudevents.http.restful.ws.impl.CloudEventsHeaders.CE_PREFIX;
+
+public final class BinaryRestfulWSMessageReaderImpl extends BaseGenericBinaryMessageReaderImpl<String, String> {
+
+    private final MultivaluedMap<String, String> headers;
+
+    public BinaryRestfulWSMessageReaderImpl(SpecVersion version, MultivaluedMap<String, String> headers, byte[] body) {
+        super(version, body != null && body.length > 0 ? BytesCloudEventData.wrap(body) : null);
+
+        Objects.requireNonNull(headers);
+        this.headers = headers;
+    }
+
+    @Override
+    protected boolean isContentTypeHeader(String key) {
+        return key.equalsIgnoreCase(HttpHeaders.CONTENT_TYPE);
+    }
+
+    @Override
+    protected boolean isCloudEventsHeader(String key) {
+        return key.length() > CE_PREFIX.length() && StringUtils.startsWithIgnoreCase(key, CE_PREFIX);
+    }
+
+    @Override
+    protected String toCloudEventsKey(String key) {
+        return key.substring(CE_PREFIX.length()).toLowerCase();
+    }
+
+    @Override
+    protected void forEachHeader(BiConsumer<String, String> fn) {
+        this.headers.forEach((k, v) -> fn.accept(k, v.get(0)));
+    }
+
+    @Override
+    protected String toCloudEventsValue(String value) {
+        return value;
+    }
+}

--- a/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/CloudEventsHeaders.java
+++ b/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/CloudEventsHeaders.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.http.restful.ws.impl;
+
+import io.cloudevents.core.message.impl.MessageUtils;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import java.util.Map;
+
+class CloudEventsHeaders {
+
+    static final String CE_PREFIX = "ce-";
+
+    static final Map<String, String> ATTRIBUTES_TO_HEADERS = MessageUtils.generateAttributesToHeadersMapping(v -> {
+        if (v.equals("datacontenttype")) {
+            return HttpHeaders.CONTENT_TYPE;
+        }
+        return CE_PREFIX + v;
+    });
+
+    static final String SPEC_VERSION = ATTRIBUTES_TO_HEADERS.get("specversion");
+
+}

--- a/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSClientMessageWriter.java
+++ b/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSClientMessageWriter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.http.restful.ws.impl;
+
+import io.cloudevents.CloudEventData;
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.format.EventFormat;
+import io.cloudevents.core.message.MessageWriter;
+import io.cloudevents.rw.CloudEventRWException;
+import io.cloudevents.rw.CloudEventWriter;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
+public final class RestfulWSClientMessageWriter implements CloudEventWriter<Void>, MessageWriter<RestfulWSClientMessageWriter, Void> {
+
+    private final ClientRequestContext context;
+
+    public RestfulWSClientMessageWriter(ClientRequestContext context) {
+        this.context = context;
+
+        // http headers could contain a content type, so let's remove it
+        this.context.getHeaders().remove(HttpHeaders.CONTENT_TYPE);
+        this.context.setEntity(null);
+    }
+
+    @Override
+    public RestfulWSClientMessageWriter create(SpecVersion version) {
+        this.context.getHeaders().add(CloudEventsHeaders.SPEC_VERSION, version.toString());
+        return this;
+    }
+
+    @Override
+    public RestfulWSClientMessageWriter withContextAttribute(String name, String value) throws CloudEventRWException {
+        String headerName = CloudEventsHeaders.ATTRIBUTES_TO_HEADERS.get(name);
+        if (headerName == null) {
+            headerName = CloudEventsHeaders.CE_PREFIX + name;
+        }
+        this.context.getHeaders().add(headerName, value);
+        return this;
+    }
+
+    @Override
+    public Void end(CloudEventData value) throws CloudEventRWException {
+        this.context.setEntity(value.toBytes());
+        return null;
+    }
+
+    @Override
+    public Void end() {
+        return null;
+    }
+
+    @Override
+    public Void setEvent(EventFormat format, byte[] value) throws CloudEventRWException {
+        this.context.setEntity(value, null, MediaType.valueOf(format.serializedContentType()));
+        return null;
+    }
+}

--- a/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageFactory.java
+++ b/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.http.restful.ws.impl;
+
+import io.cloudevents.core.message.MessageReader;
+import io.cloudevents.core.message.impl.GenericStructuredMessageReader;
+import io.cloudevents.core.message.impl.MessageUtils;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+public final class RestfulWSMessageFactory {
+
+    private RestfulWSMessageFactory() {
+    }
+
+    public static MessageReader create(MediaType mediaType, MultivaluedMap<String, String> headers, byte[] payload) throws IllegalArgumentException {
+        return MessageUtils.parseStructuredOrBinaryMessage(
+            () -> headers.getFirst(HttpHeaders.CONTENT_TYPE),
+            format -> new GenericStructuredMessageReader(format, payload),
+            () -> headers.getFirst(CloudEventsHeaders.SPEC_VERSION),
+            sv -> new BinaryRestfulWSMessageReaderImpl(sv, headers, payload)
+        );
+    }
+
+}

--- a/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageWriter.java
+++ b/http/restful-ws-jakarta/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageWriter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018-Present The CloudEvents Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.cloudevents.http.restful.ws.impl;
+
+import io.cloudevents.CloudEventData;
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.format.EventFormat;
+import io.cloudevents.core.message.MessageWriter;
+import io.cloudevents.rw.CloudEventRWException;
+import io.cloudevents.rw.CloudEventWriter;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public final class RestfulWSMessageWriter implements CloudEventWriter<Void>, MessageWriter<RestfulWSMessageWriter, Void> {
+
+    private final MultivaluedMap<String, Object> httpHeaders;
+    private final OutputStream entityStream;
+
+    public RestfulWSMessageWriter(MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) {
+        this.httpHeaders = httpHeaders;
+        this.entityStream = entityStream;
+
+        // http headers could contain a content type, so let's remove it
+        this.httpHeaders.remove(HttpHeaders.CONTENT_TYPE);
+    }
+
+    @Override
+    public RestfulWSMessageWriter create(SpecVersion version) {
+        this.httpHeaders.add(CloudEventsHeaders.SPEC_VERSION, version.toString());
+        return this;
+    }
+
+    @Override
+    public RestfulWSMessageWriter withContextAttribute(String name, String value) throws CloudEventRWException {
+        String headerName = CloudEventsHeaders.ATTRIBUTES_TO_HEADERS.get(name);
+        if (headerName == null) {
+            headerName = CloudEventsHeaders.CE_PREFIX + name;
+        }
+        this.httpHeaders.add(headerName, value);
+        return this;
+    }
+
+    @Override
+    public Void end(CloudEventData value) throws CloudEventRWException {
+        try {
+            this.entityStream.write(value.toBytes());
+        } catch (IOException e) {
+            throw CloudEventRWException.newOther(e);
+        }
+        return this.end();
+    }
+
+    @Override
+    public Void end() {
+        try {
+            this.entityStream.flush();
+        } catch (IOException e) {
+            throw CloudEventRWException.newOther(e);
+        }
+        return null;
+    }
+
+    @Override
+    public Void setEvent(EventFormat format, byte[] value) throws CloudEventRWException {
+        this.httpHeaders.add(HttpHeaders.CONTENT_TYPE, format.serializedContentType());
+        try {
+            this.entityStream.write(value);
+        } catch (IOException e) {
+            throw CloudEventRWException.newOther(e);
+        }
+        return this.end();
+    }
+}

--- a/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.client.ClientRequestFilter
+++ b/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.client.ClientRequestFilter
@@ -1,0 +1,17 @@
+#
+# Copyright 2018-Present The CloudEvents Authors
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# http://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.cloudevents.http.restful.ws.CloudEventsProvider

--- a/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
+++ b/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyReader
@@ -1,0 +1,17 @@
+#
+# Copyright 2018-Present The CloudEvents Authors
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# http://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.cloudevents.http.restful.ws.CloudEventsProvider

--- a/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
+++ b/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.ext.MessageBodyWriter
@@ -1,0 +1,17 @@
+#
+# Copyright 2018-Present The CloudEvents Authors
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# http://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.cloudevents.http.restful.ws.CloudEventsProvider

--- a/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
+++ b/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
@@ -1,1 +1,0 @@
-io.cloudevents.http.restful.ws.CloudEventsProvider

--- a/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
+++ b/http/restful-ws-jakarta/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
@@ -1,0 +1,1 @@
+io.cloudevents.http.restful.ws.CloudEventsProvider

--- a/http/restful-ws/README.md
+++ b/http/restful-ws/README.md
@@ -1,5 +1,8 @@
 # HTTP Protocol Binding for Jakarta RESTful Web Services
 
+This module is deprecated and will be removed in version 5.0.
+Please migrate to Jakarta EE 9+ and use the `cloudevents-http-restful-ws-jakarta` module instead.
+
 Javadocs: [![Javadocs](http://www.javadoc.io/badge/io.cloudevents/cloudevents-http-restful-ws.svg?color=green)](http://www.javadoc.io/doc/io.cloudevents/cloudevents-http-restful-ws)
 
 Documentation: https://cloudevents.github.io/sdk-java/http-jakarta-restful-ws

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/BinaryEncoding.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/BinaryEncoding.java
@@ -28,5 +28,6 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Deprecated // to be removed in version 5.0, use cloudevents-http-restful-ws-jakarta module instead
 public @interface BinaryEncoding {
 }

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/CloudEventsProvider.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/CloudEventsProvider.java
@@ -51,6 +51,7 @@ import java.util.Optional;
 @Provider
 @Consumes(MediaType.WILDCARD)
 @Produces(MediaType.WILDCARD)
+@Deprecated // to be removed in version 5.0, use cloudevents-http-restful-ws-jakarta module instead
 public class CloudEventsProvider implements MessageBodyReader<CloudEvent>, MessageBodyWriter<CloudEvent>, ClientRequestFilter {
 
     /**

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/StructuredEncoding.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/StructuredEncoding.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Deprecated // to be removed in version 5.0, use cloudevents-http-restful-ws-jakarta module instead
 public @interface StructuredEncoding {
     /**
      * Specify the content type of the structured mode.

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/BinaryRestfulWSMessageReaderImpl.java
@@ -29,6 +29,7 @@ import java.util.function.BiConsumer;
 
 import static io.cloudevents.http.restful.ws.impl.CloudEventsHeaders.CE_PREFIX;
 
+@Deprecated // to be removed in version 5.0, use cloudevents-http-restful-ws-jakarta module instead
 public final class BinaryRestfulWSMessageReaderImpl extends BaseGenericBinaryMessageReaderImpl<String, String> {
 
     private final MultivaluedMap<String, String> headers;

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSClientMessageWriter.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSClientMessageWriter.java
@@ -28,6 +28,7 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
+@Deprecated // to be removed in version 5.0, use cloudevents-http-restful-ws-jakarta module instead
 public final class RestfulWSClientMessageWriter implements CloudEventWriter<Void>, MessageWriter<RestfulWSClientMessageWriter, Void> {
 
     private final ClientRequestContext context;

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageFactory.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageFactory.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
+@Deprecated // to be removed in version 5.0, use cloudevents-http-restful-ws-jakarta module instead
 public final class RestfulWSMessageFactory {
 
     private RestfulWSMessageFactory() {

--- a/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageWriter.java
+++ b/http/restful-ws/src/main/java/io/cloudevents/http/restful/ws/impl/RestfulWSMessageWriter.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.io.OutputStream;
 
+@Deprecated // to be removed in version 5.0, use cloudevents-http-restful-ws-jakarta module instead
 public final class RestfulWSMessageWriter implements CloudEventWriter<Void>, MessageWriter<RestfulWSMessageWriter, Void> {
 
     private final MultivaluedMap<String, Object> httpHeaders;


### PR DESCRIPTION
As discussed in #705 and #729, see https://github.com/cloudevents/sdk-java/pull/729#pullrequestreview-4253594404, this is the first PR. The goal is to deprecate Jakarta EE 8 module and promote the Jakarta EE 9+ module.

I added Jakarta EE 9+ links in a few places where they were missing. I also fixed the links where they were still pointing to the Jakarta EE 8 module.

The examples are still using the now deprecated `cloudevents-http-restful-ws` module. The reason is - I cannot upgrade Quarkus or Jetty simply because next major releases, that are Jakarta EE 9+-compatible would also require Java at least 11, but we're still on 8.