### PR TITLE
🐛 Refactor `toReader` method in `CloudEventHttpUtils` to provide a temporary workaround to issue #704

### DIFF
--- a/spring/src/main/java/io/cloudevents/spring/http/CloudEventHttpUtils.java
+++ b/spring/src/main/java/io/cloudevents/spring/http/CloudEventHttpUtils.java
@@ -27,8 +27,6 @@ import io.cloudevents.rw.CloudEventRWException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -55,10 +53,23 @@ public class CloudEventHttpUtils {
      * @return a {@link MessageReader} representing the {@link CloudEvent}
      * @throws CloudEventRWException if something goes wrong while resolving the {@link SpecVersion} or if the message has unknown encoding
      */
+    @SuppressWarnings("unchecked")
     public static MessageReader toReader(HttpHeaders headers, Supplier<byte[]> body) throws CloudEventRWException {
-        Map<String, List<String>> headersMap = new HashMap<>();
-        headers.forEach((key, values) -> headersMap.put(key, new ArrayList<>(values)));
-        return HttpMessageFactory.createReaderFromMultimap(headersMap, body.get());
+        MessageReader reader;
+
+        // Temporary compatibility workaround for Spring Framework 7 HttpHeaders changes.
+        // Remove this branch and use the standard path once native Spring 7 support is released.
+        if (headers instanceof Map<?, ?>) {
+            reader = HttpMessageFactory.createReaderFromMultimap((Map<String, List<String>>) headers, body.get());
+        } else {
+            // Spring 7+ no longer guarantees HttpHeaders implements Map, so use the header visitor API.
+            reader = HttpMessageFactory.createReader(
+                processHeader -> headers.forEach(
+                    (key, values) -> values.forEach(value -> processHeader.accept(key, value))),
+                body.get());
+        }
+
+        return reader;
     }
 
 	/**


### PR DESCRIPTION
🐛 Refactor `toReader` method in `CloudEventHttpUtils` to provide a temporary workaround to [#704](https://github.com/cloudevents/sdk-java/issues/704)

Spring Framework 7 changed org.springframework.http.HttpHeaders so it no longer implements the Map / MultiValueMap contract.

Current versions of io.cloudevents:cloudevents-spring pass HttpHeaders directly to:

HttpMessageFactory.createReaderFromMultimap(headers, body.get()); The CloudEvents HTTP reader expects a Map<String, List<String>>, so applications running Spring Framework 7 fail while deserializing inbound CloudEvents with:

java.lang.IncompatibleClassChangeError:
Class org.springframework.http.ReadOnlyHttpHeaders does not implement the requested interface java.util.Map
In WebFlux, Reactor treats this linkage error as fatal. The HTTP exchange can remain incomplete, causing callers such as WebTestClient to report a timeout instead of the underlying exception.