### PR TITLE
fix: handle null MessageHeaders in MessageBuilderMessageWriter (#689)

### DIFF
--- a/spring/src/main/java/io/cloudevents/spring/messaging/MessageBuilderMessageWriter.java
+++ b/spring/src/main/java/io/cloudevents/spring/messaging/MessageBuilderMessageWriter.java
@@ -42,7 +42,9 @@ class MessageBuilderMessageWriter
 	private Map<String, Object> headers = new HashMap<>();
 
 	public MessageBuilderMessageWriter(Map<String, Object> headers) {
-		this.headers.putAll(headers);
+		if (headers != null) {
+			this.headers.putAll(headers);
+		}
 	}
 
 	public MessageBuilderMessageWriter() {

--- a/spring/src/test/java/io/cloudevents/spring/messaging/CloudEventMessageConverterTests.java
+++ b/spring/src/test/java/io/cloudevents/spring/messaging/CloudEventMessageConverterTests.java
@@ -128,4 +128,19 @@ class CloudEventMessageConverterTests {
 		assertThat(converter.toMessage(new byte[0], new MessageHeaders(Collections.emptyMap()))).isNull();
 	}
 
+	// gh-689: toMessage should not throw NPE when the caller provides no headers,
+	// e.g. RabbitMessagingTemplate#convertAndSend(String, Object) passes null.
+	@Test
+	void fromCloudEventWithNullHeaders() {
+		CloudEvent attributes = CloudEventBuilder.v1().withId("A234-1234-1234")
+				.withSource(URI.create("https://spring.io/")).withType("org.springframework")
+				.withData("hello".getBytes(StandardCharsets.UTF_8)).build();
+		Message<?> message = converter.toMessage(attributes, null);
+		Map<String, ?> headers = message.getHeaders();
+		assertThat(headers.get("ce-id")).isEqualTo("A234-1234-1234");
+		assertThat(headers.get("ce-specversion")).isEqualTo("1.0");
+		assertThat(headers.get("ce-source")).isEqualTo("https://spring.io/");
+		assertThat(headers.get("ce-type")).isEqualTo("org.springframework");
+	}
+
 }


### PR DESCRIPTION
## Summary

Fixes a `NullPointerException` that occurs when `CloudEventMessageConverter.toMessage()` is called with `null` `MessageHeaders` — a scenario that happens when using `RabbitMessagingTemplate#convertAndSend(String, Object)` (and similar Spring messaging templates that don't supply headers).

## Root Cause

`CloudEventMessageConverter.toMessage()` passes the `headers` argument directly to `new MessageBuilderMessageWriter(headers)`. Inside the constructor, `this.headers.putAll(headers)` was called unconditionally, throwing an NPE when `headers` is `null`.

## Fix

Added a null-guard in the `MessageBuilderMessageWriter(Map<String, Object> headers)` constructor so that a `null` input is treated as an empty map, while CloudEvent attributes are still written correctly.

## Test

Added regression test `fromCloudEventWithNullHeaders` to `CloudEventMessageConverterTests` that calls `converter.toMessage(event, null)` and asserts the returned message contains the correct CloudEvent headers.

All 9 tests in `CloudEventMessageConverterTests` pass.

Closes #689